### PR TITLE
Fix issue where changing a word form of one tile altered all instances

### DIFF
--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -98,7 +98,7 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
                 words.Add(tile.word);
 
                 //
-                rawSentence = rawSentence + tile.word.word + " ";
+                rawSentence = rawSentence + tile.textToDisplay + " ";
             }
 
             //

--- a/Assets/Scenes/Sentence Builder/Word Holder/WordHolderPopup.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/WordHolderPopup.cs
@@ -87,13 +87,10 @@ public class WordHolderPopup : MonoBehaviour
     //
     public void CloseWordHolderPopup()
     {
-        //
-        // TODO make sure to update the current tile again
-  //word.word = 
-
-        //
+        // Both of the following lines seem to be needed at the moment, 
+        // and that is probably a sign that there is a place we could simplify something.
         GameObject.Find("WordHolderDrop").GetComponentInChildren<Text>().text = transform.GetChild(midIndex).GetComponentInChildren<Text>().text;
-
+        GameObject.Find("WordHolderDrop").GetComponentInChildren<WordTile>().textToDisplay = transform.GetChild(midIndex).GetComponentInChildren<Text>().text;
         //
         Destroy(this.gameObject);
     }

--- a/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
+++ b/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
@@ -6,66 +6,51 @@ using Crosstales.RTVoice;
 
 public class WordTile : MonoBehaviour, IPointerClickHandler
 {
-    //
     //[HideInInspector]
     public Word word;
-
-    //
+    public string textToDisplay;
     private Color originalColor;
-
-    //
     private bool highlighted = false;
 
-    //
+    // When someone clicks a tile, speak the text on the tile and highlight the tile
     public void OnPointerClick(PointerEventData eventData)
     {
-        //
-        StartCoroutine(HighlightCoroutine(Speaker.ApproximateSpeechLength(this.GetComponentInChildren<Text>().text)));
+        string textToRead = this.textToDisplay;
+        
+        // Highlight the word tile for approximately as long as it will take to say the text on the tile
+        StartCoroutine(HighlightCoroutine(Speaker.ApproximateSpeechLength(textToRead)));
 
-        //
-        Speaker.SpeakNative(this.GetComponentInChildren<Text>().text, Speaker.VoiceForCulture("en"));
+        // Speak the text on the tile using the correct voice
+        Speaker.SpeakNative(textToRead, Speaker.VoiceForCulture("en"));
     }
 
     //
     public void Highlight()
     {
-        //
         Image image = GetComponent<Image>();
-
-        //
         highlighted = !highlighted;
 
-        //
         if (highlighted)
         {
-            //
             originalColor = image.color;
-
-            //
             image.color = Color.yellow;
         }
         else
         {
-            //
             image.color = originalColor;
         }
     }
 
-    //
     public void Highlight(float seconds)
     {
-        //
         StartCoroutine(HighlightCoroutine(seconds));
     }
 
-    //
     public void Highlight(float seconds, float delay)
     {
-        //
         StartCoroutine(HighlightCoroutine(seconds, delay));
     }
 
-    //
     private IEnumerator HighlightCoroutine(float seconds)
     {
         //
@@ -77,44 +62,32 @@ public class WordTile : MonoBehaviour, IPointerClickHandler
         //
         image.color = Color.yellow;
 
-        //
         yield return new WaitForSeconds(seconds);
-
-        //
         image.color = previous;
     }
 
     private IEnumerator HighlightCoroutine(float seconds, float delay)
     {
-        //
+        // The visual aspect of this word tile
         Image image = GetComponent<Image>();
 
-        //
+        // The usual color of this word tile
         Color previous = image.color;
-
-        //
         yield return new WaitForSeconds(delay);
 
-        //
+        // Set the color of the word tile to the highlight color (currently yellow)
         image.color = Color.yellow;
 
-        //
         yield return new WaitForSeconds(seconds);
-
-        //
         image.color = previous;
     }
 
     //
     public void SetUpTile(Word word)
     {
-        //
         this.word = word;
-
-        //
         this.name = word.word;
-
-        //
         this.transform.GetComponentInChildren<Text>().text = word.word;
+        this.textToDisplay = word.word;
     }
 }

--- a/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
+++ b/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
@@ -32,9 +32,9 @@ public class TextToSpeechHandler : MonoBehaviour
     private bool highlight = false;
 
     // Store all the word tile components we need for highlighting
-    private List<WordTile> words;
+    private List<WordTile> wordTiles;
 
-    //
+    // In general, we are not currently speaking the sentence
     private bool speakingSentence = false;
 
     // A tick variable represents the number of words inside a single tile
@@ -92,23 +92,19 @@ public class TextToSpeechHandler : MonoBehaviour
     }
 
     //
-    public void startSpeakingSentence(List<WordTile> words, bool highlight)
+    public void startSpeakingSentence(List<WordTile> wordTiles, bool highlight)
     {
-        //
-        this.words = words;
+        this.wordTiles = wordTiles;
         this.highlight = highlight;
 
-        //
         speakingSentence = true;
 
-        //
         string sentence = "";
 
-        //
-        foreach(WordTile word in words)
+        foreach(WordTile wordTile in wordTiles)
         {
             //
-            sentence += word.word.word + " ";
+            sentence += wordTile.textToDisplay + " ";
         }
 
         //
@@ -145,7 +141,7 @@ public class TextToSpeechHandler : MonoBehaviour
             if(highlight)
             {
                 //
-                words.Last().Highlight();
+                wordTiles.Last().Highlight();
             }
             
         }
@@ -160,24 +156,29 @@ public class TextToSpeechHandler : MonoBehaviour
         //
         if(speakingSentence)
         {
-            //
+            // The variable tick will be 0 when the previous tile is done
+            // When that is the case...
             if (tick == 0)
             {
-                //
+                // Progress to the next word tile (tracked by index)
                 index++;
 
-                //
-                tick = words[index].word.word.Split(' ').Length;
+                // The text on this tile
+                WordTile wt = wordTiles[index] as WordTile;
+                string textToRead =  wt.textToDisplay;
+
+                // Calculate the number of ticks this tile will get depending upon how many words are on the tile
+                tick = textToRead.Split(' ').Length;
 
                 //
                 if (index > 0)
                 {
                     //
-                    words[index - 1].Highlight();
+                    wordTiles[index - 1].Highlight(Speaker.ApproximateSpeechLength(textToRead));
                 }
 
                 //
-                words[index].Highlight();
+                wordTiles[index].Highlight();
             }
 
             //

--- a/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
+++ b/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
@@ -174,7 +174,7 @@ public class TextToSpeechHandler : MonoBehaviour
                 if (index > 0)
                 {
                     //
-                    wordTiles[index - 1].Highlight(Speaker.ApproximateSpeechLength(textToRead));
+                    wordTiles[index - 1].Highlight();
                 }
 
                 //


### PR DESCRIPTION
Changing one tiles word form altered all of the instances of that word tile... and things didn't match between displayed word and spoken or saved word. This commit fixes these issues. 

There may still be room for improvement here. Some things seem repetitious. I welcome feedback about how to best handle the updating of the text on the tile and the word forms.

Changing how a single word tile is spoken versus how a word tile that is in a sentence is spoken and highlighted was a much bigger job than I first anticipated.