### PR TITLE
Fix word tile duplication in the wordbank when dragged

### DIFF
--- a/Assets/Scenes/Sentence Builder/DraggableTile.cs
+++ b/Assets/Scenes/Sentence Builder/DraggableTile.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -156,6 +156,12 @@ public class DraggableTile : MonoBehaviour, IBeginDragHandler, IDragHandler, IEn
 
         //
         canvasGroup.blocksRaycasts = true;
+
+        // If we are dragging a word back into the wordbank, we don't want to duplicate it
+        if(draggedFrom == TileDropzone.Behavior.WordBank)
+        {
+            Destroy(this.gameObject);
+        }
 
         //
         Destroy(placeholder);

--- a/Assets/Scenes/Sentence Builder/TileDropzone.cs
+++ b/Assets/Scenes/Sentence Builder/TileDropzone.cs
@@ -87,8 +87,10 @@ public class TileDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
     //
     public void OnDrop(PointerEventData eventData)
     {
+        GameObject droppedtile = null;
         //
         DraggableTile d = eventData.pointerDrag.GetComponent<DraggableTile>();
+        droppedtile = eventData.pointerDrag;
 
         //
         if(d != null)
@@ -98,22 +100,27 @@ public class TileDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
             {
                 //
                 case Behavior.Default:
+                    //Debug.Log("You have place the tile in the default space.");
 
-                    //
-                    Destroy(eventData.pointerDrag);
+                    // pretty sure the eventData no longer knows what object it was dragging
+                    //Destroy(eventData.pointerDrag);
+                    Destroy(droppedtile);
+                    Destroy(d.placeholder);
 
                     break;
 
                 //
                 case Behavior.WordBank:
 
-                    //
-                    Destroy(eventData.pointerDrag);
+                    //Debug.Log("You have placed the tile in the wordbank.");
+                    Destroy(droppedtile);
+                    // fixes the New Game Objects that were being leftover when we dragged a tile from the wordbank to itself
+                    Destroy(d.placeholder);
 
                     break;
 
                 case Behavior.Trash:
-
+                    //Debug.Log("You have placed the tile in the trash.");
                     //
                     if(behavior == Behavior.Sentence)
                     {
@@ -128,6 +135,7 @@ public class TileDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
 
                 //
                 case Behavior.Sentence:
+                //Debug.Log("You have placed a tile in the sentence zone.");              
 
                     //
                     d.parentToReturnTo = this.transform;
@@ -136,18 +144,17 @@ public class TileDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
 
                 //
                 case Behavior.WordHolder:
+                //Debug.Log("You have placed a tile in the wordholder zone.");
 
                     //
                     d.parentToReturnTo = this.transform;
 
-                    //
                     if(this.transform.childCount > 0)
                     {
                         //
                         Destroy(this.transform.GetChild(0).gameObject);
                     }
-
-                    //
+                    
                     GetComponent<WordHolder>().OpenWordHolder(eventData.pointerDrag.GetComponent<WordTile>().word);
 
                     //


### PR DESCRIPTION
This is a fix for the bug we were having where dragging a word tile back into the word bank or into empty space would leave empty game objects and/or a clone of the word tile. These are now being properly deleted.