### PR TITLE
Change the TTS for the sentence bar to read each word individually

### DIFF
--- a/Assets/Scenes/Sentence Builder/Filtering/FilterController.cs
+++ b/Assets/Scenes/Sentence Builder/Filtering/FilterController.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -12,7 +12,7 @@ public class FilterController : MonoBehaviour
     private List<string> lettersToFilter = new List<string>();
     private List<int> packsToFilter = new List<int>();
 
-    private LetterFilterButton[] letterButtons = new LetterFilterButton[23];
+    private LetterFilterButton[] letterButtons = new LetterFilterButton[25];
 
     //
     private void Start()

--- a/Assets/Scenes/Sentence Builder/Text to Speech Button/TextToSpeechButton.cs
+++ b/Assets/Scenes/Sentence Builder/Text to Speech Button/TextToSpeechButton.cs
@@ -57,8 +57,8 @@ public class TextToSpeechButton : MonoBehaviour, IPointerEnterHandler, IPointerE
     //
     public void OnPointerClick(PointerEventData eventData)
     {
-        //
-        tts.startSpeakingSentence(sentence.GatherWordTiles(), true);
+        // Slowly here meaning each word tile is processed individually rather than as an entire sentence.
+        StartCoroutine(tts.startSpeakingSentenceSlowly(sentence.GatherWordTiles(), true));
     }
 
     //

--- a/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
+++ b/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
@@ -51,7 +51,7 @@ public class WordTile : MonoBehaviour, IPointerClickHandler
         StartCoroutine(HighlightCoroutine(seconds, delay));
     }
 
-    private IEnumerator HighlightCoroutine(float seconds)
+    public IEnumerator HighlightCoroutine(float seconds)
     {
         //
         Image image = GetComponent<Image>();


### PR DESCRIPTION
I've created a new method: "startSpeakingSentenceSlowly" that mimics the coroutine we use for highlighting individual tiles and applied it to a foreach loop that goes through all the word tiles in the sentence bar.

I've also commented out some old bits of code in the TextToSpeechHandler.cs file that seemed to be breaking things.

This might have also fixed the sentence bar highlighting issues on mac (issue #28), but I can't really test that. 