### PR TITLE
Make scrollbar move with tts

### DIFF
--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -137,32 +137,19 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
         yield return new WaitForSecondsRealtime(2);
         currentImage.sprite = upLever;
     }
-    // currently just pops in one word at a time without an animation
-    // to use this method, comment out the two lines below it:
-    // completedSentences.GetComponentInChildren<Text>().text = rawSentence;
-    // revealSentenceAnimation(rawSentence, words);
-    // private IEnumerator revealSentenceWordByWord(List<Word> words) {
-    //     // if a sentence is already in the box we need to clear it before showing a new one
-    //     if (completedSentences.GetComponentInChildren<Text>().text != null){
-    //         completedSentences.GetComponentInChildren<Text>().text = "";
-    //     }
-    //     foreach(Word word in words) {
-    //     completedSentences.GetComponentInChildren<Text>().text += word.word + " ";
-    //     yield return new WaitForSecondsRealtime(1);
-    //     }
-        
-    // }
 
     // method to slowly reveal the already completed sentence
     // this will move from right to left, making it look like it's coming out of the pipe instead of just appearing.
     private IEnumerator revealSentenceAnimation(List<WordTile> wordTiles){
+        float approxSpeechTime;
+        approxSpeechTime = tts.getApproxSpeechTime(wordTiles);
         // set position to right so animation actually moves from somewhere
         completedSentences.GetComponentInChildren<Text>().rectTransform.position += new Vector3(760f,0f,0f);
         // wait for TTS to go for a bit before revealing
         // having an animation here eventually would be nice
-        yield return new WaitForSeconds(tts.getApproxSpeechTime(wordTiles) / 3);
+        yield return new WaitForSeconds(approxSpeechTime / 3);
         // moving the entire group of words to the center over a total time of 1 second per word (which should change to the approx of tts later)
-        LeanTween.moveX(completedSentences.GetComponentInChildren<Text>().rectTransform, 0f, tts.getApproxSpeechTime(wordTiles));
+        LeanTween.moveX(completedSentences.GetComponentInChildren<Text>().rectTransform, 0f, approxSpeechTime);
         // make sure the animation starts at 350 pixels to the right
         completedSentences.GetComponentInChildren<Text>().rectTransform.position += new Vector3(300f,0f,0f);
     }

--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -123,7 +123,7 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
             StartCoroutine(revealSentenceAnimation(tiles));
             
 
-            StartCoroutine(sentence.GetComponent<SentenceBar>().ClearTiles());
+            StartCoroutine(sentence.GetComponent<SentenceBar>().ClearTiles2());
 
         }
 	}

--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -33,6 +33,8 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
     //
     private Image currentImage;
 
+    GameObject sentenceScrollBar;
+
 	/// <summary>
 	/// Start this instance.
 	/// </summary>
@@ -43,6 +45,7 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
 
 		defaultSize = this.transform.GetComponent<Image>().rectTransform.sizeDelta;
 		highlightSize = new Vector2 (defaultSize.x + 10, defaultSize.y + 10);
+        sentenceScrollBar = GameObject.FindGameObjectWithTag("SentenceBar");
 	}
 		
 	/// <summary>
@@ -79,6 +82,9 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
         // Pull the lever kronk!
         StartCoroutine(pullLever());
 
+        // reset the scrollbar when the submit sentence animation begins
+        sentenceScrollBar.GetComponent<Scrollbar>().value = 0;
+
         //
         List<WordTile> tiles = sentence.GatherWordTiles();
 
@@ -114,7 +120,7 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
             //StartCoroutine(revealSentenceWordByWord(words));
             completedSentences.GetComponentInChildren<Text>().text = rawSentence;
             // animate the big block of sentence to the left for approximately how long it takes for the speaker to speak it
-            revealSentenceAnimation(tiles);
+            StartCoroutine(revealSentenceAnimation(tiles));
             
 
             StartCoroutine(sentence.GetComponent<SentenceBar>().ClearTiles());
@@ -149,9 +155,12 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
 
     // method to slowly reveal the already completed sentence
     // this will move from right to left, making it look like it's coming out of the pipe instead of just appearing.
-    private void revealSentenceAnimation(List<WordTile> wordTiles){
+    private IEnumerator revealSentenceAnimation(List<WordTile> wordTiles){
         // set position to right so animation actually moves from somewhere
-        completedSentences.GetComponentInChildren<Text>().rectTransform.position += new Vector3(300f,0f,0f);
+        completedSentences.GetComponentInChildren<Text>().rectTransform.position += new Vector3(760f,0f,0f);
+        // wait for TTS to go for a bit before revealing
+        // having an animation here eventually would be nice
+        yield return new WaitForSeconds(tts.getApproxSpeechTime(wordTiles) / 3);
         // moving the entire group of words to the center over a total time of 1 second per word (which should change to the approx of tts later)
         LeanTween.moveX(completedSentences.GetComponentInChildren<Text>().rectTransform, 0f, tts.getApproxSpeechTime(wordTiles));
         // make sure the animation starts at 350 pixels to the right

--- a/Assets/Scenes/Sentence Builder/Sentence/SentenceBar.cs
+++ b/Assets/Scenes/Sentence Builder/Sentence/SentenceBar.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Crosstales.RTVoice;
@@ -8,17 +8,19 @@ using UnityEngine.UI;
 public class SentenceBar : MonoBehaviour
 {
     //
-    private readonly int tileSize = 125;
+    private float tileSize = 130f;
 
     //
     private Vector2 originalSize;
 
-    //
+    // 
     private RectTransform r;
 
     int animcount = 1;
 
     public TextToSpeechHandler tts;
+
+    float futureWidth = 0;
 
     //
     private void Start()
@@ -50,17 +52,16 @@ public class SentenceBar : MonoBehaviour
     //
     public void ResizeSentence(int amountOfTileSpaceToAdd)
     {
-        //
+
+        // if the word tiles haven't taken up more space than can be displayed...
         if(GatherWordTiles().Count * tileSize < originalSize.x)
         {
-            //
+            // do nothing
             return;
         }
 
-        //
-        float futureWidth = r.sizeDelta.x + (amountOfTileSpaceToAdd * tileSize);
-
-        //
+        futureWidth = r.sizeDelta.x + (amountOfTileSpaceToAdd * tileSize);
+        
         if(futureWidth > originalSize.x)
         {
             //
@@ -142,7 +143,7 @@ public class SentenceBar : MonoBehaviour
 
             // the time each frame will take
             float yield_time = animation_time/frame_count;
-            float tile_height = 100;
+            float tile_height = 105;
             //float tile_height = child.gameObject.GetComponent<RectTransform>().rect.height + 50; 
 
             // the distance the tile will move each frame

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -697,8 +697,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: -201}
-  m_SizeDelta: {x: 750, y: 85}
+  m_AnchoredPosition: {x: 7.5999994, y: -201}
+  m_SizeDelta: {x: 780, y: 95}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &170142082
 MonoBehaviour:
@@ -802,7 +802,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -437.5, y: -241.50002}
+  m_AnchoredPosition: {x: -437.5, y: -212.4}
   m_SizeDelta: {x: 95, y: 95}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &406503547
@@ -974,7 +974,7 @@ GameObject:
   - component: {fileID: 455542564}
   m_Layer: 5
   m_Name: SentenceScrollbar
-  m_TagString: Untagged
+  m_TagString: SentenceBar
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1043,7 +1043,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1321135474}
   m_HandleRect: {fileID: 1321135473}
   m_Direction: 0
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -2105,7 +2105,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 750, y: 150}
+  m_SizeDelta: {x: 780, y: 150}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &934462493
 MonoBehaviour:
@@ -2194,7 +2194,7 @@ MonoBehaviour:
   m_ChildAlignment: 3
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 154.25, y: 85}
+  m_CellSize: {x: 130, y: 85}
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 2
   m_ConstraintCount: 1
@@ -3675,7 +3675,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -443, y: -147}
+  m_AnchoredPosition: {x: -444.9, y: -118.8}
   m_SizeDelta: {x: 125, y: 125}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1696695521
@@ -4615,7 +4615,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 115}
+  m_AnchoredPosition: {x: 7.6, y: 115.9}
   m_SizeDelta: {x: 830, y: 103}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1944421431

--- a/Assets/Scenes/Sentence Builder/TileDropzone.cs
+++ b/Assets/Scenes/Sentence Builder/TileDropzone.cs
@@ -14,6 +14,11 @@ public class TileDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
         WordHolder,
         WordBank
     }
+    private GameObject sentenceBar;
+
+    public void start() {
+        sentenceBar = GameObject.Find("Sentence");
+    }
 
     //
     public Behavior behavior = Behavior.Default;
@@ -44,6 +49,10 @@ public class TileDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
             if(d.draggedFrom != Behavior.Sentence && behavior == Behavior.Sentence)
             {
                 //
+                GetComponent<SentenceBar>().ResizeSentence(1);
+            }
+            if (d.draggedFrom == Behavior.Sentence && behavior == Behavior.Sentence)
+            {
                 GetComponent<SentenceBar>().ResizeSentence(1);
             }
         }
@@ -81,6 +90,11 @@ public class TileDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
                 //
                 GetComponent<SentenceBar>().ResizeSentence(-1);
             }
+
+            if (d.draggedFrom == Behavior.Sentence && behavior == Behavior.Sentence)
+            {
+                GetComponent<SentenceBar>().ResizeSentence(-1);
+            }
         }
     }
 
@@ -111,7 +125,6 @@ public class TileDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
 
                 //
                 case Behavior.WordBank:
-
                     //Debug.Log("You have placed the tile in the wordbank.");
                     Destroy(droppedtile);
                     // fixes the New Game Objects that were being leftover when we dragged a tile from the wordbank to itself

--- a/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
+++ b/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
@@ -185,7 +185,7 @@ public class TextToSpeechHandler : MonoBehaviour
             // formula to calculate the value change needed to move the scrollbar one tile over is: (n) / (n)^2
             // where n = numTiles - 6 and comes from our knowledge that only 6 tiles will fit in the viewport at a time, 
             // so we only care about moving the scrollbar after things start getting out of view
-            float n = wordTiles.Count - 6; 
+            float n = wordTiles.Count - 6; // move scrollbar before reaching final word in viewport for context
 
             scrollbarValueIncrement = n/(n * n);
         }
@@ -202,9 +202,9 @@ public class TextToSpeechHandler : MonoBehaviour
 
             // approx how long it takes TTS to speak the word
             float timeToSpeak = Speaker.ApproximateSpeechLength(tileText) * (1/voiceRate);
+            int numberTilesReadBeforeScrolling = 4; // change this if you want begin scrolling earlier or later. (so if this were 6, the max number of tiles in view, scrolling wouldn't begin until TTS reached the last tile in the sentence bar)
 
-            // if we've gone past the 6 tiles in view and we aren't on the last six tiles
-            if (loopCounter > 6) {
+            if (loopCounter > numberTilesReadBeforeScrolling) {  
                 // move the scrollbar one tile over so they stay in view
                 sentenceScrollbar.value += scrollbarValueIncrement;
                 incrementCounter++;

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - VoiceList
+  - SentenceBar
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
This fixes issues #36 and #37.

Note: a bug appeared somewhere along the line that breaks the TTS when clicking on word tiles in the sentence bar and in the word holder. This is fixed in the resubmit-sentence branch, so don't worry about it here. It should be fixed when that branch is merged into master.