### PR TITLE
Resubmit sentence

### DIFF
--- a/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+public class SaveSentenceTiles : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+{
+    public static GameObject draggedObject;
+    private Vector3 startPosition;
+    public List<WordTile> savedSentence; // storage for the latest submitted word tiles in case the user wishes to modify their sentence
+    // Start is called before the first frame update
+    private bool dragging;
+
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        draggedObject = gameObject;
+        startPosition = transform.position;
+    }
+
+    public void OnDrag(PointerEventData eventData)
+    {
+        transform.position = Input.mousePosition;
+    }
+
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        draggedObject = null;
+        transform.position = startPosition; //bounce back testing
+    }
+
+
+}

--- a/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs
@@ -9,7 +9,6 @@ public class SaveSentenceTiles : MonoBehaviour, IBeginDragHandler, IDragHandler,
     int startSibIndex;
     private Vector3 startPosition;
     public List<WordTile> savedSentence; // storage for the latest submitted word tiles in case the user wishes to modify their sentence
-    // Start is called before the first frame update
     private bool dragging;
     private GameObject sentence = null;
     private bool drop = false;
@@ -19,29 +18,20 @@ public class SaveSentenceTiles : MonoBehaviour, IBeginDragHandler, IDragHandler,
         sentence = GameObject.Find("Sentence");
     }    
 
-    // seems like we'll need to stop blocking raycasts on the object we are dragging so that we can actually detect stuff beneath it
     public void OnBeginDrag(PointerEventData eventData)
     {
         draggedObject = gameObject;
         startPosition = transform.position;
         startSibIndex = transform.GetSiblingIndex();
+        transform.SetAsLastSibling();
+        transform.GetComponent<Image>().raycastTarget = false; // stop the object from blocking raycasts
     }
 
     public void OnDrag(PointerEventData eventData)
     {
-        // Debug.Log(eventData.pointerCurrentRaycast.gameObject.name);
         transform.position = Input.mousePosition;
-        // if(eventData.hovered.Contains(sentence)){
-        //     drop = true; //hovering over the sentence view, we want to resubmit the sentence
-        //     transform.SetAsLastSibling();// ensure the dragged object is over the sentence view
-        // } else {
-        //     drop = false;
-        //     transform.SetSiblingIndex(startSibIndex); // drop the dragged object back below the sentence view so that eventData.hovered can still detect it
-        // }
     }
 
-    // There's a bit of a weird quirk of eventData.hovered here, in that it seems to only work in finding objects that are below what we are dragging in the hierarchy.
-    // Because of this sentence resubmission will break if SentenceScrollview ever finds its way above MostRecentSavedSentence
     public void OnEndDrag(PointerEventData eventData)
     {
         // if we drag and release our sentence over the sentence bar, resubmit it
@@ -49,10 +39,10 @@ public class SaveSentenceTiles : MonoBehaviour, IBeginDragHandler, IDragHandler,
         {
             resubmitSentence(draggedObject.GetComponentInChildren<SaveSentenceTiles>().savedSentence);
         }
-        // reset the submitted sentence object back to its original position
         draggedObject = null;
-        transform.position = startPosition;
+        transform.position = startPosition; // reset the submitted sentence object back to its original position
         transform.SetSiblingIndex(startSibIndex); // reset parent so dragged object is no longer on top of everything
+        transform.GetComponent<Image>().raycastTarget = true; // allow raycasts to hit the object again so we can drag it later
     }
 
     // note: with current implementation, the resubmitted word tiles cannot be placed in between word tiles in the sentence bar. They will always append themselves to the end.

--- a/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs
@@ -10,7 +10,7 @@ public class SaveSentenceTiles : MonoBehaviour, IBeginDragHandler, IDragHandler,
     public List<WordTile> savedSentence; // storage for the latest submitted word tiles in case the user wishes to modify their sentence
     // Start is called before the first frame update
     private bool dragging;
-
+    
     public void OnBeginDrag(PointerEventData eventData)
     {
         draggedObject = gameObject;
@@ -24,8 +24,30 @@ public class SaveSentenceTiles : MonoBehaviour, IBeginDragHandler, IDragHandler,
 
     public void OnEndDrag(PointerEventData eventData)
     {
+        GameObject sentence = GameObject.Find("Sentence");
+        // if we drag and release our sentence over the sentence bar, resubmit it
+        if (eventData.hovered.Contains(sentence))
+        {
+            resubmitSentence(draggedObject.GetComponent<SaveSentenceTiles>().savedSentence);
+        }
+        // reset the submitted sentence object back to its original position
         draggedObject = null;
-        transform.position = startPosition; //bounce back testing
+        transform.position = startPosition;
+    }
+
+    // note: with current implementation, the resubmitted word tiles cannot be placed in between word tiles in the sentence bar. They will always append themselves to the end.
+    // Not sure if we want to be able to stuff the resubmitted sentence between words that have already been placed or not.
+    public void resubmitSentence(List<WordTile> sentenceTiles)
+    {
+        GameObject sentence = GameObject.Find("Sentence");
+        foreach(WordTile wordtile in sentenceTiles)
+        {
+            // copy the word tile object and make it a child of SentenceInTiles 
+            GameObject wordTileCopy = Instantiate(wordtile.gameObject, this.transform);
+            sentence.GetComponent<SentenceBar>().ResizeSentence(1);
+            // move the copy word tile over to the sentence bar
+            wordTileCopy.transform.SetParent(sentence.transform);
+        }
     }
 
 

--- a/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs
@@ -6,33 +6,53 @@ using UnityEngine.EventSystems;
 public class SaveSentenceTiles : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
 {
     public static GameObject draggedObject;
+    int startSibIndex;
     private Vector3 startPosition;
     public List<WordTile> savedSentence; // storage for the latest submitted word tiles in case the user wishes to modify their sentence
     // Start is called before the first frame update
     private bool dragging;
+    private GameObject sentence = null;
+    private bool drop = false;
     
+    public void Start()
+    {
+        sentence = GameObject.Find("Sentence");
+    }    
+
+    // seems like we'll need to stop blocking raycasts on the object we are dragging so that we can actually detect stuff beneath it
     public void OnBeginDrag(PointerEventData eventData)
     {
         draggedObject = gameObject;
         startPosition = transform.position;
+        startSibIndex = transform.GetSiblingIndex();
     }
 
     public void OnDrag(PointerEventData eventData)
     {
+        // Debug.Log(eventData.pointerCurrentRaycast.gameObject.name);
         transform.position = Input.mousePosition;
+        // if(eventData.hovered.Contains(sentence)){
+        //     drop = true; //hovering over the sentence view, we want to resubmit the sentence
+        //     transform.SetAsLastSibling();// ensure the dragged object is over the sentence view
+        // } else {
+        //     drop = false;
+        //     transform.SetSiblingIndex(startSibIndex); // drop the dragged object back below the sentence view so that eventData.hovered can still detect it
+        // }
     }
 
+    // There's a bit of a weird quirk of eventData.hovered here, in that it seems to only work in finding objects that are below what we are dragging in the hierarchy.
+    // Because of this sentence resubmission will break if SentenceScrollview ever finds its way above MostRecentSavedSentence
     public void OnEndDrag(PointerEventData eventData)
     {
-        GameObject sentence = GameObject.Find("Sentence");
         // if we drag and release our sentence over the sentence bar, resubmit it
         if (eventData.hovered.Contains(sentence))
         {
-            resubmitSentence(draggedObject.GetComponent<SaveSentenceTiles>().savedSentence);
+            resubmitSentence(draggedObject.GetComponentInChildren<SaveSentenceTiles>().savedSentence);
         }
         // reset the submitted sentence object back to its original position
         draggedObject = null;
         transform.position = startPosition;
+        transform.SetSiblingIndex(startSibIndex); // reset parent so dragged object is no longer on top of everything
     }
 
     // note: with current implementation, the resubmitted word tiles cannot be placed in between word tiles in the sentence bar. They will always append themselves to the end.

--- a/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs.meta
+++ b/Assets/Scenes/Sentence Builder/Lever/SaveSentenceTiles.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16871521c83a9fd4d9e1d8e8b3e5bce2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -179,11 +179,8 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
     // this will move from right to left, making it look like it's coming out of the pipe instead of just appearing.
     private void revealSentenceAnimation(List<WordTile> wordTiles){
         // set position to right so animation actually moves from somewhere
-        completedSentences.GetComponentInChildren<Text>().rectTransform.position += new Vector3(300f,0f,0f);
-        // moving the entire group of words to the center over a total time of 1 second per word (which should change to the approx of tts later)
-        LeanTween.moveX(completedSentences.GetComponentInChildren<Text>().rectTransform, 0f, tts.getApproxSpeechTime(wordTiles));
-        // make sure the animation starts at 350 pixels to the right
-        completedSentences.GetComponentInChildren<Text>().rectTransform.position += new Vector3(300f,0f,0f);
+        completedSentences.position += new Vector3(800f,0f,0f); // sentence game object
+        LeanTween.moveX(completedSentences.gameObject, 600f, tts.getApproxSpeechTime(wordTiles));
     }
     
 }

--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -180,7 +180,7 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
     private void revealSentenceAnimation(List<WordTile> wordTiles){
         // set position to right so animation actually moves from somewhere
         completedSentences.position += new Vector3(800f,0f,0f); // sentence game object
-        LeanTween.moveX(completedSentences.gameObject, 600f, tts.getApproxSpeechTime(wordTiles));
+        LeanTween.moveLocalX(completedSentences.gameObject, 0f, tts.getApproxSpeechTime(wordTiles));
     }
     
 }

--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -81,8 +81,9 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
 
         //
         List<WordTile> tiles = sentence.GatherWordTiles();
+        completedSentences.GetComponentInChildren<SaveSentenceTiles>().savedSentence = copyTiles(tiles); // store all the tiles from our completed sentence in a new list
 
-        // If there is words in sentence
+        // If there are words in the sentence
         if (tiles.Count > 0)
         {
             //
@@ -112,7 +113,7 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
 
             //
             //StartCoroutine(revealSentenceWordByWord(words));
-            completedSentences.GetComponentInChildren<Text>().text = rawSentence;
+            completedSentences.GetComponentInChildren<Text>().text = rawSentence; // place the raw text of the completed sentence into the most recent saved sentence game object
             // animate the big block of sentence to the left for approximately how long it takes for the speaker to speak it
             revealSentenceAnimation(tiles);
             
@@ -121,6 +122,33 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
 
         }
 	}
+
+    // copies all the wordtiles in the list so that when the original word tiles are deleted for the animation, we still have copies
+    // in case the user wants to drag their submitted sentence back into the sentence bar
+    // While this may seem weird, but just copying the list doesn't work because the actual word tile objects themselves are being destroyed, so the list references break otherwise
+    private List<WordTile> copyTiles(List<WordTile> wordTiles)
+    {
+        GameObject temp = GameObject.Find("SentenceInTiles");
+
+        // if we already have copies from previous sentence submissions, destroy them
+        if(temp.transform.childCount > 0) 
+        {
+            foreach(Transform child in temp.transform)
+            {
+                Destroy(child.gameObject);
+            }
+        }
+
+        List<WordTile> copiedTiles = new List<WordTile>();
+        WordTile copyTile = null;
+        
+        foreach(WordTile wordtile in wordTiles)
+        {
+            copyTile = Instantiate(wordtile, temp.transform); // copy the wordtile and make it a child of the SentenceInTiles game object
+            copiedTiles.Add(copyTile);
+        }
+        return copiedTiles;
+    }
 
     /// <summary>
     /// Changes the lever image to the down position for 2 seconds, then reset it

--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -125,7 +125,7 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
 
     // copies all the wordtiles in the list so that when the original word tiles are deleted for the animation, we still have copies
     // in case the user wants to drag their submitted sentence back into the sentence bar
-    // While this may seem weird, but just copying the list doesn't work because the actual word tile objects themselves are being destroyed, so the list references break otherwise
+    // While this may seem weird, just copying the list doesn't work because the actual word tile objects themselves are being destroyed, so the list references break otherwise
     private List<WordTile> copyTiles(List<WordTile> wordTiles)
     {
         GameObject temp = GameObject.Find("SentenceInTiles");

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -378,7 +378,7 @@ RectTransform:
   - {fileID: 31156710}
   - {fileID: 1844566991}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -488,19 +488,19 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 461907522}
   - {fileID: 1108083714}
   - {fileID: 1944421430}
   - {fileID: 626752468}
   - {fileID: 1696695520}
   - {fileID: 244709234}
   - {fileID: 107012080}
-  - {fileID: 170142081}
-  - {fileID: 455542563}
   - {fileID: 960626487}
   - {fileID: 138376905}
   - {fileID: 690792488}
   - {fileID: 1494685787}
+  - {fileID: 461907522}
+  - {fileID: 455542563}
+  - {fileID: 170142081}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -542,7 +542,7 @@ RectTransform:
   - {fileID: 1692775391}
   - {fileID: 2010578503}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 10
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -693,7 +693,7 @@ RectTransform:
   m_Children:
   - {fileID: 934462492}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 7
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -798,7 +798,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -993,7 +993,7 @@ RectTransform:
   m_Children:
   - {fileID: 1927914322}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 8
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -1043,7 +1043,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1321135474}
   m_HandleRect: {fileID: 1321135473}
   m_Direction: 0
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -1100,6 +1100,7 @@ GameObject:
   - component: {fileID: 461907522}
   - component: {fileID: 461907524}
   - component: {fileID: 461907523}
+  - component: {fileID: 461907525}
   m_Layer: 5
   m_Name: MostRecentSavedSentence
   m_TagString: Untagged
@@ -1120,7 +1121,7 @@ RectTransform:
   m_Children:
   - {fileID: 2092331156}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 0
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1140,14 +1141,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.745283, g: 0.745283, b: 0.745283, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sprite: {fileID: 21300000, guid: 5111258645361d04a839608aef708347, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1165,6 +1166,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 461907521}
   m_CullTransparentMesh: 0
+--- !u!114 &461907525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 461907521}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 16871521c83a9fd4d9e1d8e8b3e5bce2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  savedSentence: []
 --- !u!1 &470935014
 GameObject:
   m_ObjectHideFlags: 0
@@ -1459,7 +1473,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -1668,7 +1682,7 @@ RectTransform:
   - {fileID: 1411588350}
   - {fileID: 430250085}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 11
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2249,7 +2263,7 @@ RectTransform:
   - {fileID: 1697865870}
   - {fileID: 1428679919}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 9
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2431,7 +2445,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2753,7 +2767,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 786042619}
   m_HandleRect: {fileID: 786042618}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -2903,7 +2917,7 @@ RectTransform:
   - {fileID: 660259757}
   - {fileID: 1706701413}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 12
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3685,7 +3699,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -4639,7 +4653,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5086,7 +5100,6 @@ GameObject:
   - component: {fileID: 2092331156}
   - component: {fileID: 2092331158}
   - component: {fileID: 2092331157}
-  - component: {fileID: 2092331159}
   m_Layer: 5
   m_Name: SentenceInTiles
   m_TagString: Untagged
@@ -5126,7 +5139,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -5135,10 +5148,10 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: 37543c271391eba479d41b64114e906f, type: 3}
-    m_FontSize: 14
+    m_FontSize: 35
     m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 10
+    m_BestFit: 0
+    m_MinSize: 2
     m_MaxSize: 40
     m_Alignment: 4
     m_AlignByGeometry: 0
@@ -5146,9 +5159,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: '
-
-'
+  m_Text: 
 --- !u!222 &2092331158
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -5157,16 +5168,3 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2092331155}
   m_CullTransparentMesh: 0
---- !u!114 &2092331159
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2092331155}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 16871521c83a9fd4d9e1d8e8b3e5bce2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  savedSentence: []

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -499,8 +499,9 @@ RectTransform:
   - {fileID: 690792488}
   - {fileID: 1494685787}
   - {fileID: 461907522}
-  - {fileID: 455542563}
   - {fileID: 170142081}
+  - {fileID: 455542563}
+  - {fileID: 376243637}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -693,7 +694,7 @@ RectTransform:
   m_Children:
   - {fileID: 934462492}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -805,6 +806,36 @@ RectTransform:
   m_AnchoredPosition: {x: -437.5, y: -241.50002}
   m_SizeDelta: {x: 95, y: 95}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &376243636
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 376243637}
+  m_Layer: 0
+  m_Name: DragObjectParent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &376243637
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 376243636}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -51.133373, y: -62.47609, z: -153.88554}
+  m_LocalScale: {x: 0.8486188, y: 0.8486188, z: 0.8486188}
+  m_Children: []
+  m_Father: {fileID: 138288539}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &406503547
 GameObject:
   m_ObjectHideFlags: 0
@@ -993,7 +1024,7 @@ RectTransform:
   m_Children:
   - {fileID: 1927914322}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -378,7 +378,7 @@ RectTransform:
   - {fileID: 31156710}
   - {fileID: 1844566991}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -488,6 +488,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
+  - {fileID: 461907522}
+  - {fileID: 1805874015}
   - {fileID: 1108083714}
   - {fileID: 1944421430}
   - {fileID: 626752468}
@@ -498,10 +500,8 @@ RectTransform:
   - {fileID: 138376905}
   - {fileID: 690792488}
   - {fileID: 1494685787}
-  - {fileID: 461907522}
   - {fileID: 170142081}
   - {fileID: 455542563}
-  - {fileID: 376243637}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -543,7 +543,7 @@ RectTransform:
   - {fileID: 1692775391}
   - {fileID: 2010578503}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 7
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -694,7 +694,7 @@ RectTransform:
   m_Children:
   - {fileID: 934462492}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -799,43 +799,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 4
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: -437.5, y: -241.50002}
   m_SizeDelta: {x: 95, y: 95}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &376243636
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 376243637}
-  m_Layer: 0
-  m_Name: DragObjectParent
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &376243637
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 376243636}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -51.133373, y: -62.47609, z: -153.88554}
-  m_LocalScale: {x: 0.8486188, y: 0.8486188, z: 0.8486188}
-  m_Children: []
-  m_Father: {fileID: 138288539}
-  m_RootOrder: 13
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &406503547
 GameObject:
   m_ObjectHideFlags: 0
@@ -1024,7 +994,7 @@ RectTransform:
   m_Children:
   - {fileID: 1927914322}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 12
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -1152,11 +1122,11 @@ RectTransform:
   m_Children:
   - {fileID: 2092331156}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 10
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -283}
+  m_AnchoredPosition: {x: 900, y: -283}
   m_SizeDelta: {x: 650, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &461907523
@@ -1504,7 +1474,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -1713,7 +1683,7 @@ RectTransform:
   - {fileID: 1411588350}
   - {fileID: 430250085}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 8
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2294,7 +2264,7 @@ RectTransform:
   - {fileID: 1697865870}
   - {fileID: 1428679919}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 6
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2476,7 +2446,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2948,7 +2918,7 @@ RectTransform:
   - {fileID: 660259757}
   - {fileID: 1706701413}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 9
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -3730,7 +3700,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 3
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
@@ -3963,6 +3933,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1706701412}
+  m_CullTransparentMesh: 0
+--- !u!1 &1805874014
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1805874015}
+  - component: {fileID: 1805874017}
+  - component: {fileID: 1805874016}
+  m_Layer: 5
+  m_Name: HidePipeProtrusions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1805874015
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1805874014}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 138288539}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 446.86, y: -286}
+  m_SizeDelta: {x: 130.5581, y: 140.58759}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1805874016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1805874014}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1805874017
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1805874014}
   m_CullTransparentMesh: 0
 --- !u!1001 &1808540773
 PrefabInstance:
@@ -4684,7 +4729,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -5171,7 +5216,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -2768,7 +2768,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 786042619}
   m_HandleRect: {fileID: 786042618}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -3968,8 +3968,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 446.86, y: -286}
-  m_SizeDelta: {x: 130.5581, y: 140.58759}
+  m_AnchoredPosition: {x: 531.94, y: -286}
+  m_SizeDelta: {x: 300.71487, y: 140.58759}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1805874016
 MonoBehaviour:

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -1043,7 +1043,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1321135474}
   m_HandleRect: {fileID: 1321135473}
   m_Direction: 0
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -2080,6 +2080,7 @@ GameObject:
   - component: {fileID: 934462498}
   - component: {fileID: 934462496}
   - component: {fileID: 934462495}
+  - component: {fileID: 934462497}
   m_Layer: 5
   m_Name: Sentence
   m_TagString: Untagged
@@ -2173,6 +2174,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   behavior: 2
+--- !u!114 &934462497
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 934462491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c41175d977c86004ea456bfc404791a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audio: {fileID: 138376906}
 --- !u!114 &934462498
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2739,7 +2753,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 786042619}
   m_HandleRect: {fileID: 786042618}
   m_Direction: 2
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -4192,6 +4206,7 @@ GameObject:
   - component: {fileID: 1844566992}
   - component: {fileID: 1844566993}
   - component: {fileID: 1844566994}
+  - component: {fileID: 1844566995}
   m_Layer: 5
   m_Name: WordHolderDrop
   m_TagString: Untagged
@@ -4269,6 +4284,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   WordHolderPopupPrefab: {fileID: 7750693819245514385, guid: b09922eedca48954098599ceb74aeab6,
     type: 3}
+--- !u!114 &1844566995
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1844566990}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c41175d977c86004ea456bfc404791a3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audio: {fileID: 138376906}
 --- !u!114 &1844566996
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5058,8 +5086,9 @@ GameObject:
   - component: {fileID: 2092331156}
   - component: {fileID: 2092331158}
   - component: {fileID: 2092331157}
+  - component: {fileID: 2092331159}
   m_Layer: 5
-  m_Name: Text
+  m_Name: SentenceInTiles
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -5128,3 +5157,16 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2092331155}
   m_CullTransparentMesh: 0
+--- !u!114 &2092331159
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2092331155}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 16871521c83a9fd4d9e1d8e8b3e5bce2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  savedSentence: []

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -1158,7 +1158,7 @@ MonoBehaviour:
   m_FillClockwise: 1
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_PixelsPerUnitMultiplier: 2
 --- !u!222 &461907524
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -2768,7 +2768,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 786042619}
   m_HandleRect: {fileID: 786042618}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:

--- a/Assets/Scenes/Sentence Builder/VoiceSelectionHub/VoiceSelectionHubInstantiation.cs
+++ b/Assets/Scenes/Sentence Builder/VoiceSelectionHub/VoiceSelectionHubInstantiation.cs
@@ -22,10 +22,7 @@ public class VoiceSelectionHubInstantiation : MonoBehaviour
     }
 
     // method that assigns voices to the three different change voice buttons
-    // currently just nabs first 3 voices in system
-
-    // TODO: implement logic checks for when there aren't enough voices in the system
-    // Grab only from english cultures
+    // currently just nabs first 3 en-US voices in system
     public void AssignVoices() {
         int i = 0;
         int numEnVoices = 0; // tracking index of next voice insertion point

--- a/Assets/Scenes/Story Builder/SentenceDropzone.cs
+++ b/Assets/Scenes/Story Builder/SentenceDropzone.cs
@@ -11,7 +11,7 @@ public class SentenceDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandle
         Default,
         SentenceBank,
         Page,
-        Trash
+        Trash,
     }
 
     //


### PR DESCRIPTION
Fixes issue #38

Looking for feedback on whether we want kids to be able to place the re submitted sentence in between other word tiles in the sentence bar. As things stand right now, it just appends it to the end.

This branch also fixes an unlisted bug where clicking on word tiles in the sentence bar or the word holder wouldn't play TTS.