### PR TITLE
Filtering saved sentences

### DIFF
--- a/Assets/Scenes/Story Builder/Sentence Bank/LoadSavedSentences.cs
+++ b/Assets/Scenes/Story Builder/Sentence Bank/LoadSavedSentences.cs
@@ -1,52 +1,50 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System;
+using System.Linq;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using UnityEngine;
 
 public static class LoadSavedSentences
 {
-    //
+    public static string path = Path.Combine(Application.dataPath, "Saves", "Sentences");
+
     public static List<SavedSentence> LoadSentences()
     {
-        //
-        string[] savedSentences = Directory.GetFiles(Path.Combine(Application.dataPath, "Saves", "Sentences"), "*.sen");
+        // Create a DirectoryInfo of the directory of the files to enumerate.
+        DirectoryInfo DirInfo = new DirectoryInfo(@path);
+        // DateTime StartDate = new DateTime(2021, 02, 20);
+        DateTime today = DateTime.Today;
 
-        //
+        // LINQ query for all files created past a certain date.
+        var files = from f in DirInfo.EnumerateFiles()
+           // where f.CreationTimeUtc > StartDate
+           where f.CreationTimeUtc > today
+           where f.Name.EndsWith(".sen")
+           orderby f.CreationTimeUtc descending
+           select f;
+           
+        // Show results.
         List<SavedSentence> sentencesToReturn = new List<SavedSentence>();
 
-        //
-        for(int i = 0; i < savedSentences.Length; i++)
-        {
-            //
-            FileStream file = new FileStream(savedSentences[i], FileMode.Open);
-            
-            //
-            try
-            {
-                //
+        foreach (var file in files) {
+            FileStream filestream = File.Open(Path.Combine(@path, file.Name), FileMode.Open);
+            try {
                 BinaryFormatter bf = new BinaryFormatter();
-
-                //
-                SavedSentence newSentence = (SavedSentence)bf.Deserialize(file);
-
-                //
-                sentencesToReturn.Add(newSentence);
+                SavedSentence thisSentence = (SavedSentence)bf.Deserialize(filestream);
+                sentencesToReturn.Add(thisSentence);
             }
-            catch(SerializationException e)
-            {
-                //
+            catch(SerializationException e) {
                 Debug.LogError("Cannot deserialize. " + e);
             }
-            finally
-            {
+            finally {
                 // Clean up
-                file.Close();
+                filestream.Close();
             }
         }
-
-        //
+        
         return sentencesToReturn;
     }
 


### PR DESCRIPTION
We discussed that it might be overwhelming to see all of the sentences you've ever created in the sentence bank. It seems likely that people may wish to see sentences they have created in this session or on this day, so this pull request starts with that as a default.

One thing I noticed in the process of setting this up is that saving sentences does not seem to currently save the proper form of the words or that if it is saved, that information does not seem to make it into the sentence bank. That is something to look into.