### PR TITLE
Word bank resize

### DIFF
--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -4455,7 +4455,7 @@ MonoBehaviour:
   m_ChildAlignment: 0
   m_StartCorner: 0
   m_StartAxis: 0
-  m_CellSize: {x: 175, y: 75}
+  m_CellSize: {x: 145.83, y: 50}
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 0
   m_ConstraintCount: 2

--- a/Assets/Scenes/Sentence Builder/Word Bank/BuildWorldBankNew.cs
+++ b/Assets/Scenes/Sentence Builder/Word Bank/BuildWorldBankNew.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 public class BuildWorldBankNew : MonoBehaviour
 {
     //
-    private readonly int TILE_HEIGHT = 75;
+    private readonly int TILE_HEIGHT = 50;
     private readonly int TILES_PER_ROW = 6;
 
     // Class that holds all of the words

--- a/Assets/Scenes/Sentence Builder/Word Bank/BuildWorldBankNew.cs
+++ b/Assets/Scenes/Sentence Builder/Word Bank/BuildWorldBankNew.cs
@@ -7,7 +7,7 @@ public class BuildWorldBankNew : MonoBehaviour
 {
     //
     private readonly int TILE_HEIGHT = 75;
-    private readonly int TILES_PER_ROW = 5;
+    private readonly int TILES_PER_ROW = 6;
 
     // Class that holds all of the words
     private List<Word> words;

--- a/Assets/Scenes/Sentence Builder/Word Bank/WordBank.cs
+++ b/Assets/Scenes/Sentence Builder/Word Bank/WordBank.cs
@@ -9,10 +9,10 @@ public class WordBank : MonoBehaviour
     public List<WordTile> words;
 
     // The number of tiles that can fit inside of one row of the word bank
-    private readonly int tilesPerRow = 5;
+    private readonly int tilesPerRow = 6;
 
     //
-    private readonly int tileHeight = 75;
+    private readonly int tileHeight = 50;
 
     //
     public void ResizeWordBank(int numEnabledTiles)


### PR DESCRIPTION
The goal of this branch is to resize tiles in the word bank so that it is somewhat less of a focus (putting somewhat more focus on the sentence the child is constructing).