### PR TITLE
Fixes the highlighting bug that kept tiles yellow after double clicks

### DIFF
--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -124,7 +124,7 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
             revealSentenceAnimation(tiles);
             
 
-            StartCoroutine(sentence.GetComponent<SentenceBar>().ClearTiles2());
+            StartCoroutine(sentence.GetComponent<SentenceBar>().ClearTiles());
 
         }
 	}

--- a/Assets/Scenes/Sentence Builder/Sentence/SentenceBar.cs
+++ b/Assets/Scenes/Sentence Builder/Sentence/SentenceBar.cs
@@ -74,64 +74,8 @@ public class SentenceBar : MonoBehaviour
         }
     }
 
-    // ClearTiles() now also animates the tiles it is clearing before actually deleting them.
-    public IEnumerator ClearTiles()
-    {
-        // animation time will be used to tell each part of the animation how long it gets to play.
-        // we need this in order to keep our animations in sync with TTS.
-        float animation_time =  0;
-        int animation_segments = 3;
-        int length = this.transform.childCount;
-        int updatingLength = length;
-        float left_move_distance = 0;
-        // finding the distance between any two tiles
-        if(length > 1){
-        left_move_distance = this.transform.GetChild(1).transform.position.x - this.transform.GetChild(0).transform.position.x;
-        }
-        // this cannot be a for each loop. It turns out that destroying the game objects that the for each loop uses to
-        // determine where it is in the loop causes very bad things to happen.
-        for(int i = 0; i < length; i++)
-        {
-            
-            // estimate the time it will take to speak a tile
-            // so we can run this in parallel with text to speech
-            
-            string tileText = this.transform.GetChild(0).GetComponentInChildren<Text>().text; // we destroy a tile every loop and that moves our indices by one, so using a constant here works
-            float timeToSpeak = Speaker.ApproximateSpeechLength(tileText) / tts.getVoiceRate(); // voice rate is a float that acts as a percentage so 1 = 100% and 1.5 = 150%
-            // logic here is that if we have x animations, we want each of their times to add up to timeToSpeak, so each animation gets timeToSpeak/x time to animate
-            animation_time = timeToSpeak/animation_segments;
-
-            // this initial wait time is here so we can see the word highlight and speak before it starts moving all over the place.
-            yield return new WaitForSeconds(animation_time);
-
-            StartCoroutine(animateTileUp(this.transform.GetChild(0), animation_time));
-            yield return new WaitForSeconds(animation_time);
-
-            // if we have multiple objects left in the list
-            if(updatingLength > 1){
-                // animate all but the first object in the list to the left
-                for(int a = 1; a < updatingLength; a++){
-                    StartCoroutine(animateTileLeft(this.transform.GetChild(a), animation_time, left_move_distance));
-                }
-            }
-            yield return new WaitForSeconds(animation_time);
-            //yield return new WaitForEndOfFrame();
-
-            // By destroying the first child, we change the indices of the child array
-            // So if we were to use i here, we would destroy every other game object and eventually find ourselves outside of the array.
-            Destroy(this.transform.GetChild(0).gameObject);
-
-            // we need the sentence bar length to match our changed number of game objects
-            ResizeSentence(-1);
-            updatingLength--;
-            
-            // the re-size of our hierarchy of gameObjects needs a frame to properly update
-            yield return null;
-        }
-
-    }
     // leantween version
-    public IEnumerator ClearTiles2()
+    public IEnumerator ClearTiles()
     {
         // animation time will be used to tell each part of the animation how long it gets to play.
         // we need this in order to keep our animations in sync with TTS.

--- a/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
+++ b/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
@@ -12,6 +12,15 @@ public class WordTile : MonoBehaviour, IPointerClickHandler
     private Color originalColor;
     private bool highlighted = false; 
     public TextToSpeechHandler TTS;
+    private Image image = null;
+
+
+    private void Start()
+    {
+        image = GetComponent<Image>();
+        originalColor = image.color;
+        
+    }
 
     // When someone clicks a tile, speak the text on the tile and highlight the tile
     public void OnPointerClick(PointerEventData eventData)
@@ -52,36 +61,22 @@ public class WordTile : MonoBehaviour, IPointerClickHandler
     {
         StartCoroutine(HighlightCoroutine(seconds, delay));
     }
-
+    // this one
+    // remove this comment when comitting
     public IEnumerator HighlightCoroutine(float seconds)
     {
-        //
-        Image image = GetComponent<Image>();
-
-        //
-        Color previous = image.color;
-
-        //
         image.color = Color.yellow;
-
         yield return new WaitForSeconds(seconds);
-        image.color = previous;
+        image.color = originalColor;
     }
 
     private IEnumerator HighlightCoroutine(float seconds, float delay)
     {
-        // The visual aspect of this word tile
-        Image image = GetComponent<Image>();
-
-        // The usual color of this word tile
-        Color previous = image.color;
         yield return new WaitForSeconds(delay);
-
-        // Set the color of the word tile to the highlight color (currently yellow)
         image.color = Color.yellow;
 
         yield return new WaitForSeconds(seconds);
-        image.color = previous;
+        image.color = originalColor;
     }
 
     //

--- a/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
+++ b/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
@@ -211,7 +211,6 @@ public class TextToSpeechHandler : MonoBehaviour
             }
 
             StartCoroutine(wordTile.HighlightCoroutine(timeToSpeak));
-            //Speaker.SpeakNative(tileText, Speaker.VoiceForCulture("en"));
             Speaker.Speak(tileText.ToLower(), audio, Speaker.VoiceForName(voiceName), true, voiceRate, 1f, null, voicePitch);
             //Debug.Log(voiceName);
 

--- a/Assets/Scenes/Story Builder/Saved Sentence/SentenceTile.cs
+++ b/Assets/Scenes/Story Builder/Saved Sentence/SentenceTile.cs
@@ -11,6 +11,13 @@ public class SentenceTile : MonoBehaviour, IPointerClickHandler
     private Color originalColor;
     private bool highlighted = false; 
     public TextToSpeechHandler TTS;
+    private Image image = null;
+
+    private void Start() 
+    {
+        image = GetComponent<Image>();
+        originalColor = image.color;
+    }
 
     // When someone clicks a tile, speak the text on the tile and highlight the tile
     public void OnPointerClick(PointerEventData eventData)
@@ -39,61 +46,11 @@ public class SentenceTile : MonoBehaviour, IPointerClickHandler
         TTS.startSpeakingWordTile(textToRead);
     }
 
-    //
-    public void Highlight()
-    {
-        Image image = GetComponent<Image>();
-        highlighted = !highlighted;
-
-        if (highlighted)
-        {
-            originalColor = image.color;
-            image.color = Color.yellow;
-        }
-        else
-        {
-            image.color = originalColor;
-        }
-    }
-
-    public void Highlight(float seconds)
-    {
-        StartCoroutine(HighlightCoroutine(seconds));
-    }
-
-    public void Highlight(float seconds, float delay)
-    {
-        StartCoroutine(HighlightCoroutine(seconds, delay));
-    }
-
     public IEnumerator HighlightCoroutine(float seconds)
     {
-        //
-        Image image = GetComponent<Image>();
-
-        //
-        Color previous = image.color;
-
-        //
         image.color = Color.yellow;
-
         yield return new WaitForSeconds(seconds);
-        image.color = previous;
+        image.color = originalColor;
     }
 
-    private IEnumerator HighlightCoroutine(float seconds, float delay)
-    {
-        // The visual aspect of this word tile
-        Image image = GetComponent<Image>();
-
-        // The usual color of this word tile
-        Color previous = image.color;
-        yield return new WaitForSeconds(delay);
-
-        // Set the color of the word tile to the highlight color (currently yellow)
-        image.color = Color.yellow;
-
-        yield return new WaitForSeconds(seconds);
-        image.color = previous;
-    }
 }


### PR DESCRIPTION
The previous implementation was grabbing the image color as it was being asked to highlight, so if it was already in the process of highlighting it would grab the yellow color as its original and get stuck there. Original color determination now takes place on startup rather than when it's called.

Also cleaned up some old comments and removed the original ClearTiles() method that was causing weird lag spikes on mac. Some SentenceTile highlighting methods that weren't being used were also removed.

Side note: null reference errors on the storybuilder side of things are fixed in another branch.

Closes #47