### PR TITLE
Fixes null-reference exceptions in the storybuilder scene

### DIFF
--- a/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
+++ b/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
@@ -12,6 +12,7 @@ using Crosstales.RTVoice.Model.Event;
 using Crosstales.RTVoice.Model;
 using UnityEngine.UI;
 using Crosstales.RTVoice.Tool;
+using UnityEngine.SceneManagement;
 
 public class TextToSpeechHandler : MonoBehaviour
 {
@@ -80,7 +81,11 @@ public class TextToSpeechHandler : MonoBehaviour
         }
         voiceName = Speaker.Voices[0].Name; // default voice assigned here so compiler stops whining
 
-        sentenceScrollbar = GameObject.Find("SentenceScrollbar").GetComponent<Scrollbar>();
+        // prevents TTS Handler from throwing nullreference exceptions in the storybuilder scene by trying to look for the SentenceScrollbar
+        if (SceneManager.GetActiveScene().name == "SentenceBuilder")
+        {
+            sentenceScrollbar = GameObject.Find("SentenceScrollbar").GetComponent<Scrollbar>();
+        }
 
         //==================
         // CONCEPT: Being able to change your selected voices


### PR DESCRIPTION
TTS handler recently got implemented on the storybuilder side of things, and was throwing these errors when trying to find an object from the sentencebuilder scene. It now checks to see if it's in the sentencebuilder scene before doing so.