### PR TITLE
Fix wordbank dropzone not working properly

### DIFF
--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -1675,7 +1675,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -142.99988, y: 252.00069}
+  m_AnchoredPosition: {x: -142.99988, y: 252.00043}
   m_SizeDelta: {x: 280, y: 500}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &396208986
@@ -2652,6 +2652,7 @@ MonoBehaviour:
     type: 3}
   pageIconContainer: {fileID: 1145678817}
   maxPageCount: 30
+  selectedPageGlobal: -1
 --- !u!114 &526344201
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5644,6 +5645,7 @@ MonoBehaviour:
     type: 3}
   pageContainer: {fileID: 526344200}
   maxPageCount: 30
+  selectedPage: -1
 --- !u!1 &1162990579
 GameObject:
   m_ObjectHideFlags: 0
@@ -6017,7 +6019,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1969722462}
   m_Direction: 2
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.965565
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -8741,6 +8743,7 @@ GameObject:
   - component: {fileID: 1697865873}
   - component: {fileID: 1697865872}
   - component: {fileID: 1697865871}
+  - component: {fileID: 1697865874}
   m_Layer: 5
   m_Name: Viewport
   m_TagString: Untagged
@@ -8819,6 +8822,19 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1697865869}
   m_CullTransparentMesh: 0
+--- !u!114 &1697865874
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1697865869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4a05895d77bb1f4eac53821ae4f2799, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  behavior: 4
 --- !u!1 &1706009897
 GameObject:
   m_ObjectHideFlags: 0
@@ -10117,9 +10133,9 @@ GameObject:
   - component: {fileID: 1900388510}
   - component: {fileID: 1900388512}
   - component: {fileID: 1900388511}
-  - component: {fileID: 1900388513}
   - component: {fileID: 1900388514}
   - component: {fileID: 1900388515}
+  - component: {fileID: 1900388517}
   m_Layer: 5
   m_Name: WordBankContentNew
   m_TagString: Untagged
@@ -10184,19 +10200,6 @@ MonoBehaviour:
   m_Spacing: {x: 0, y: 0}
   m_Constraint: 0
   m_ConstraintCount: 2
---- !u!114 &1900388513
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1900388509}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c4a05895d77bb1f4eac53821ae4f2799, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  behavior: 4
 --- !u!114 &1900388514
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10224,6 +10227,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   audio: {fileID: 138376906}
   sentenceScrollbar: {fileID: 0}
+--- !u!222 &1900388517
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1900388509}
+  m_CullTransparentMesh: 0
 --- !u!1 &1927914321
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Previously word tiles wouldn't delete properly when placed over top of empty space in the wordbank. (they would only delete when over top another word tile in the bank) This was fixed by attaching the dropzone script to the viewport (which actually accepts raycasts, unlike the previous game object it was attached to)