### PR TITLE
Fix bug where TTS would double up when clicking TTS button and lever

### DIFF
--- a/Assets/Scenes/Main Menu/Scripts/LearnerSelectPopup.cs
+++ b/Assets/Scenes/Main Menu/Scripts/LearnerSelectPopup.cs
@@ -39,8 +39,6 @@ public class LearnerSelectPopup : MonoBehaviour
 
     public void SetUpLearnerButtons()
     {
-        Debug.Log("making buttons for user: " + currentUser?.name);
-        Debug.Log("User doesn't have the appropriate sprites: " + !AlreadyHaveAppropriateLearnerSprites());
         //if we don't have the learner sprites we need already, go get them
         if (!AlreadyHaveAppropriateLearnerSprites())
         {
@@ -49,7 +47,6 @@ public class LearnerSelectPopup : MonoBehaviour
                 //for every learner that actually has an icon...
                 if (learner.icon != null)
                 {
-                    Debug.Log("grabbing learner icon for: " + learner.name);
                     //grabs the firebase image URI => sends server request => updates image component field in the button
                     GetLearnerIconAndMakeButton(learner);
                 }
@@ -60,7 +57,6 @@ public class LearnerSelectPopup : MonoBehaviour
         //otherwise, if we already have the sprites, just make the buttons without talking to firebase
         else
         {
-            Debug.Log("making buttons with local files...");
             foreach (Learner learner in currentUser.learners)
             {
                 CreateLearnerButton(learner);
@@ -91,7 +87,6 @@ public class LearnerSelectPopup : MonoBehaviour
         {
             if (learner._id == Path.GetFileNameWithoutExtension(fileName))
             {
-                Debug.Log("adding learner sprite to button from local file...");
                 byte[] icon = File.ReadAllBytes(fileName);
                 //LearnerImage component of learner button prefab
                 button.transform.GetChild(1).GetComponent<Image>().sprite = GetSprite(icon);
@@ -130,7 +125,6 @@ public class LearnerSelectPopup : MonoBehaviour
             {
                 if (Path.GetFileNameWithoutExtension(fileName) == learner._id)
                 {
-                    Debug.Log("matching file name found! We have the appropriate learner sprites!");
                     return true;
                 }
             }

--- a/Assets/Scenes/Main Menu/Scripts/UserLogin.cs
+++ b/Assets/Scenes/Main Menu/Scripts/UserLogin.cs
@@ -133,10 +133,8 @@ public class UserLogin : MonoBehaviour
     }
     public async void Login()
     {
-        Debug.Log("login called");
         if (userInputIsValid())
         {
-            Debug.Log("starting firebase sign-in task...");
             // waiting for this task to finish kinda kills the point of having an async function, but (as far as I know) a syncronous version doesn't exist
             // and this is just a login button anyway
             await firebaseAuth.SignInWithEmailAndPasswordAsync(email, password).ContinueWith(getUser =>

--- a/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
+++ b/Assets/Scenes/Sentence Builder/Lever/SubmitSentenceButton.cs
@@ -36,89 +36,97 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
     public Animator conveyorAnimator;
     public Animator pipesAnimator;
 
-	/// <summary>
-	/// Start this instance.
-	/// </summary>
-	void Start()
+    /// <summary>
+    /// Start this instance.
+    /// </summary>
+    void Start()
     {
         // get a reference to the current image so it can be swapped later
         currentImage = this.GetComponent<Image>();
 
-		defaultSize = this.transform.GetComponent<Image>().rectTransform.sizeDelta;
-		highlightSize = new Vector2 (defaultSize.x + 10, defaultSize.y + 10);
+        defaultSize = this.transform.GetComponent<Image>().rectTransform.sizeDelta;
+        highlightSize = new Vector2(defaultSize.x + 10, defaultSize.y + 10);
         sentenceScrollBar = GameObject.FindGameObjectWithTag("SentenceBar");
-	}
-		
-	/// <summary>
-	/// Raises the pointer enter event.
-	/// Increases the size of the submit sentence button image.
-	/// </summary>
-	/// <param name="eventData">Event data.</param>
-	public void OnPointerEnter (PointerEventData eventData)
+    }
+
+    /// <summary>
+    /// Raises the pointer enter event.
+    /// Increases the size of the submit sentence button image.
+    /// </summary>
+    /// <param name="eventData">Event data.</param>
+    public void OnPointerEnter(PointerEventData eventData)
     {
         //
         currentImage.rectTransform.sizeDelta = highlightSize;
-	}
+    }
 
-	/// <summary>
-	/// Raises the pointer exit event.
-	/// Decreases the size of the submit sentence button image.
-	/// </summary>
-	/// <param name="eventData">Event data.</param>
-	public void OnPointerExit (PointerEventData eventData)
+    /// <summary>
+    /// Raises the pointer exit event.
+    /// Decreases the size of the submit sentence button image.
+    /// </summary>
+    /// <param name="eventData">Event data.</param>
+    public void OnPointerExit(PointerEventData eventData)
     {
         //
         currentImage.rectTransform.sizeDelta = defaultSize;
-	}
+    }
 
 
-		
-	/// <summary>
-	/// Raises the pointer click event.
-	/// Submits the sentence to the completed sentences list.
-	/// </summary>
-	/// <param name="eventData">Event data.</param>
-	public void OnPointerClick (PointerEventData eventData)
-    {;
-        // Pull the lever kronk!
-        StartCoroutine(pullLever());
 
-        // reset the scrollbar when the submit sentence animation begins
-        sentenceScrollBar.GetComponent<Scrollbar>().value = 0;
-        List<WordTile> tiles = sentence.GatherWordTiles();
-        // If there are words in the sentence
-        if (tiles.Count > 0)
+    /// <summary>
+    /// Raises the pointer click event.
+    /// Submits the sentence to the completed sentences list.
+    /// </summary>
+    /// <param name="eventData">Event data.</param>
+    public void OnPointerClick(PointerEventData eventData)
+    {
+        if (TextToSpeechHandler.speakingSentence == false)
         {
-            string rawSentence = "";
-            foreach(WordTile tile in tiles)
+            // Pull the lever kronk!
+            StartCoroutine(pullLever());
+
+            // reset the scrollbar when the submit sentence animation begins
+            sentenceScrollBar.GetComponent<Scrollbar>().value = 0;
+            List<WordTile> tiles = sentence.GatherWordTiles();
+            // If there are words in the sentence
+            if (tiles.Count > 0)
             {
-                // track the submitted word
-                LearnerDataHandler.UpdateWordCount(tile.textToDisplay);
-                rawSentence = rawSentence + tile.textToDisplay + " ";
+                string rawSentence = "";
+                foreach (WordTile tile in tiles)
+                {
+                    // track the submitted word
+                    LearnerDataHandler.UpdateWordCount(tile.textToDisplay);
+                    rawSentence = rawSentence + tile.textToDisplay + " ";
+                }
+                LearnerDataHandler.StoreLearnerData();
+                StartCoroutine(ServerRequestHandler.PostLearnerDataToServer());
+
+                rawSentence = rawSentence.Remove(rawSentence.Length - 1, 1);
+
+                // Save to json. This is temporary and is taking the place of a database;
+                SaveSentenceHandler.SaveSentence(tiles);
+                StartCoroutine(ServerRequestHandler.PostSentence(SaveSentenceHandler.mostRecentSentence));
+                float speakDuration = tts.getApproxSpeechTime(tiles);
+                StartCoroutine(animateConveyorBelt(speakDuration));
+                StartCoroutine(animatePipes(speakDuration));
+                StartCoroutine(tts.startSpeakingSentenceSlowly(tiles, false));
+
+                //
+                //StartCoroutine(revealSentenceWordByWord(words));
+                completedSentences.GetComponentInChildren<Text>().text = rawSentence; // place the raw text of the completed sentence into the most recent saved sentence game object
+                                                                                      // animate the big block of sentence to the left for approximately how long it takes for the speaker to speak it
+                revealSentenceAnimation(tiles);
+
+                StartCoroutine(sentence.GetComponent<SentenceBar>().AnimateAndTransferTiles());
+
             }
-            LearnerDataHandler.StoreLearnerData();
-            StartCoroutine(ServerRequestHandler.PostLearnerDataToServer());
-
-            rawSentence = rawSentence.Remove(rawSentence.Length - 1, 1);
-
-            // Save to json. This is temporary and is taking the place of a database;
-            SaveSentenceHandler.SaveSentence(tiles);
-            StartCoroutine(ServerRequestHandler.PostSentence(SaveSentenceHandler.mostRecentSentence));
-            float speakDuration = tts.getApproxSpeechTime(tiles);
-            StartCoroutine(animateConveyorBelt(speakDuration));
-            StartCoroutine(animatePipes(speakDuration));
-            StartCoroutine(tts.startSpeakingSentenceSlowly(tiles, false));
-
-            //
-            //StartCoroutine(revealSentenceWordByWord(words));
-            completedSentences.GetComponentInChildren<Text>().text = rawSentence; // place the raw text of the completed sentence into the most recent saved sentence game object
-            // animate the big block of sentence to the left for approximately how long it takes for the speaker to speak it
-            revealSentenceAnimation(tiles);
-            
-            StartCoroutine(sentence.GetComponent<SentenceBar>().AnimateAndTransferTiles());
-
         }
-	}
+        else
+        {
+            // maybe the button should shake left an right here to show that it's unavailable while TTS is already going?
+            Debug.Log("TTS already reading sentence, please wait.");
+        }
+    }
 
     /// <summary>
     /// Changes the lever image to the down position for 2 seconds, then reset it
@@ -137,7 +145,7 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
         float approxSpeechTime;
         approxSpeechTime = tts.getApproxSpeechTime(wordTiles);
         // set position to right so animation actually moves from somewhere
-        completedSentences.position += new Vector3(800f,0f,0f); // sentence game object
+        completedSentences.position += new Vector3(800f, 0f, 0f); // sentence game object
         LeanTween.moveLocalX(completedSentences.gameObject, 0f, tts.getApproxSpeechTime(wordTiles));
     }
 
@@ -154,5 +162,5 @@ public class SubmitSentenceButton : MonoBehaviour, IPointerEnterHandler, IPointe
         yield return new WaitForSeconds(duration + 1f);
         pipesAnimator.SetBool("ProcessingTile", false);
     }
-    
+
 }

--- a/Assets/Scenes/Sentence Builder/Text to Speech Button/TextToSpeechButton.cs
+++ b/Assets/Scenes/Sentence Builder/Text to Speech Button/TextToSpeechButton.cs
@@ -12,21 +12,22 @@ using UnityEngine.EventSystems;
 using Crosstales.RTVoice;
 using Crosstales.RTVoice.Model.Event;
 
-public class TextToSpeechButton : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerClickHandler  {
-	
+public class TextToSpeechButton : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerClickHandler
+{
 
-	// Blue speaker image
+
+    // Blue speaker image
     [Header("Images")]
-	public Image playAudioImage;
+    public Image playAudioImage;
 
-	// Red square image
-	public Image stopAudioImage;
+    // Red square image
+    public Image stopAudioImage;
 
-	// Red cross image
-	public Image noVoicesImage;
+    // Red cross image
+    public Image noVoicesImage;
 
-	// Play/stop image must be changed accordingly
-	private Image buttonImage;
+    // Play/stop image must be changed accordingly
+    private Image buttonImage;
 
     //
     [Header("Objects in Scene")]
@@ -37,51 +38,57 @@ public class TextToSpeechButton : MonoBehaviour, IPointerEnterHandler, IPointerE
     private Vector2 defaultSize, highlightSize;
 
     //
-	void Start()
+    void Start()
     {
-		// Get a reference to the button image to swap play/stop images
-		buttonImage = this.GetComponent<Image>();
+        // Get a reference to the button image to swap play/stop images
+        buttonImage = this.GetComponent<Image>();
 
-		// No voices available
-		if (!TextToSpeechHandler.voicesAvailable)
+        // No voices available
+        if (!TextToSpeechHandler.voicesAvailable)
         {
-			buttonImage.sprite = noVoicesImage.sprite;
-			buttonImage.rectTransform.sizeDelta = new Vector2 (75, 75);
-		}
+            buttonImage.sprite = noVoicesImage.sprite;
+            buttonImage.rectTransform.sizeDelta = new Vector2(75, 75);
+        }
 
-		// Set resize image dimensions
-		defaultSize = buttonImage.rectTransform.sizeDelta;
-		highlightSize = new Vector2 (defaultSize.x + 10, defaultSize.y + 10);
-	}
+        // Set resize image dimensions
+        defaultSize = buttonImage.rectTransform.sizeDelta;
+        highlightSize = new Vector2(defaultSize.x + 10, defaultSize.y + 10);
+    }
 
     //
     public void OnPointerClick(PointerEventData eventData)
     {
         List<WordTile> words;
         words = sentence.GatherWordTiles();
-        // Slowly here meaning each word tile is processed individually rather than as an entire sentence.
-        StartCoroutine(tts.startSpeakingSentenceSlowly(words, true));
-        // track all the words in the sentence
-        foreach(WordTile wordTile in words)
+        if (TextToSpeechHandler.speakingSentence == false)
         {
-            LearnerDataHandler.UpdateWordCount(wordTile.word.baseWord);
+            // Slowly here meaning each word tile is processed individually rather than as an entire sentence.
+            StartCoroutine(tts.startSpeakingSentenceSlowly(words, true));
+            // track all the words in the sentence
+            foreach (WordTile wordTile in words)
+            {
+                LearnerDataHandler.UpdateWordCount(wordTile.word.baseWord);
+            }
+            LearnerDataHandler.StoreLearnerData();
+            StartCoroutine(ServerRequestHandler.PostLearnerDataToServer());
         }
-        LearnerDataHandler.StoreLearnerData();
-        StartCoroutine(ServerRequestHandler.PostLearnerDataToServer());
-        
+        else
+        {
+            Debug.Log("TTS already reading sentence, please wait.");
+        }
     }
 
     //
-    public void OnPointerEnter (PointerEventData eventData)
+    public void OnPointerEnter(PointerEventData eventData)
     {
         //
-		buttonImage.rectTransform.sizeDelta = highlightSize;
-	}
-		
+        buttonImage.rectTransform.sizeDelta = highlightSize;
+    }
+
     //
-	public void OnPointerExit (PointerEventData eventData)
+    public void OnPointerExit(PointerEventData eventData)
     {
         //
         buttonImage.rectTransform.sizeDelta = defaultSize;
-	}
+    }
 }

--- a/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
+++ b/Assets/Scenes/Shared Scenes/TextToSpeechHandler.cs
@@ -50,7 +50,7 @@ public class TextToSpeechHandler : MonoBehaviour
     private List<WordTile> wordTiles;
 
     // In general, we are not currently speaking the sentence
-    public bool speakingSentence = false;
+    public static bool speakingSentence = false;
 
     // A tick variable represents the number of words inside a single tile
     private int tick = 0;
@@ -61,7 +61,7 @@ public class TextToSpeechHandler : MonoBehaviour
     public Scrollbar sentenceScrollbar;
 
     private float scrollbarValueIncrement = 0;
-    
+
     // max number of word tiles that can be in view at once, needs to be changed if the size of the sentence bar or its tiles change
     private int maxTilesPerSentence = 6;
 
@@ -75,7 +75,7 @@ public class TextToSpeechHandler : MonoBehaviour
         Speaker.OnSpeakStart += speakStartMethod;
         Speaker.OnSpeakComplete += speakCompleteMethod;
         //Debug.Log("there are " + Speaker.Voices.Count + " voices on the system.");
-        
+
         // Check if voices are available
         if (Speaker.Voices.Count <= 0)
         {
@@ -102,9 +102,10 @@ public class TextToSpeechHandler : MonoBehaviour
 
     // this will take the text stored in a button and set the speaker to that voice
     // change speaker will be associated with several buttons that each know the name of their voices
-    public void changeSpeaker() {
+    public void changeSpeaker()
+    {
         voiceName = this.gameObject.GetComponentInChildren<Text>().text;
-        Speaker.Speak("Hello!", audio,  Speaker.VoiceForName(voiceName), true, voiceRate, voicePitch);
+        Speaker.Speak("Hello!", audio, Speaker.VoiceForName(voiceName), true, voiceRate, voicePitch);
     }
 
     // keeping this because we want the sentence to be read more fluently once the sentence has been "built"
@@ -117,7 +118,7 @@ public class TextToSpeechHandler : MonoBehaviour
 
         string sentence = "";
 
-        foreach(WordTile wordTile in wordTiles)
+        foreach (WordTile wordTile in wordTiles)
         {
             //
             sentence += wordTile.textToDisplay + " ";
@@ -128,21 +129,24 @@ public class TextToSpeechHandler : MonoBehaviour
 
         //
         Speaker.Speak(sentence, audio, Speaker.VoiceForName(voiceName), true, voiceRate, 1f, null, voicePitch);
-        
+
     }
 
-    public void startSpeakingWordTile(string word){
+    public void startSpeakingWordTile(string word)
+    {
         Speaker.Speak(word, audio, Speaker.VoiceForName(voiceName), true, voiceRate, 1f, "", voicePitch);
         //Debug.Log(voicePitch);
     }
 
     // grabs the slider value of an attached slider game object and sets it as the voice rate
-    public void changeVoiceRate() {
+    public void changeVoiceRate()
+    {
         voiceRate = this.GetComponent<Slider>().value;
     }
 
     // grabs the slider value of an attached slider game object and sets it as the voice pitch
-    public void changeVoicePitch() {
+    public void changeVoicePitch()
+    {
         voicePitch = this.GetComponent<Slider>().value;
         audio.pitch = voicePitch;
     }
@@ -151,47 +155,46 @@ public class TextToSpeechHandler : MonoBehaviour
     /// This makes each word more emphasized, with more time between each word.
     /// </summary>
     // This will probably only be used on the TextToSpeech button so the kids can get more practice with identifying their soon to-be sentence.
-    public IEnumerator startSpeakingSentenceSlowly(List<WordTile> wordTiles, bool highlight){
+    public IEnumerator startSpeakingSentenceSlowly(List<WordTile> wordTiles, bool highlight)
+    {
 
         this.wordTiles = wordTiles;
         this.highlight = highlight;
-        
-        // if TTS is already going, we will stop it from saying something else
-        if(speakingSentence == true){
-            stopSpeaking();
-        }
 
         speakingSentence = true;
 
         // 6 tiles fit in the sentence bar, so if we have more than that, we need to consider moving the scrollbar alongside the highlighting/TTS
-        if(wordTiles.Count > 6) {
+        if (wordTiles.Count > 6)
+        {
             // making sure the first tile is in view when TTS begins speaking
             // seems to be working, but gives the slider a weird initial value. Not sure why that is
             sentenceScrollbar.value = 0;
-            
+
             // formula to calculate the value change needed to move the scrollbar one tile over is: (n) / (n)^2
             // where n = numTiles - 6 and comes from our knowledge that only 6 tiles will fit in the viewport at a time, 
             // so we only care about moving the scrollbar after things start getting out of view
             float n = wordTiles.Count - 6; // move scrollbar before reaching final word in viewport for context
 
-            scrollbarValueIncrement = n/(n * n);
+            scrollbarValueIncrement = n / (n * n);
         }
 
         int loopCounter = 0;
         int incrementCounter = 0;
 
         // iterate through all the word tiles we have in the sentence and activate TTS and highlighting on each one individually
-        foreach(WordTile wordTile in wordTiles){
+        foreach (WordTile wordTile in wordTiles)
+        {
 
             loopCounter++; // tracking when we need to move the scrollbar
-            // store the text of the word tile
+                           // store the text of the word tile
             string tileText = wordTile.GetComponentInChildren<Text>().text;
 
             // approx how long it takes TTS to speak the word
             float timeToSpeak = Speaker.ApproximateSpeechLength(tileText) / (voiceRate);
             int numberTilesReadBeforeScrolling = 4; // change this if you want begin scrolling earlier or later. (so if this were 6, the max number of tiles in view, scrolling wouldn't begin until TTS reached the last tile in the sentence bar)
 
-            if (loopCounter > numberTilesReadBeforeScrolling) {  
+            if (loopCounter > numberTilesReadBeforeScrolling)
+            {
                 // move the scrollbar one tile over so they stay in view
                 sentenceScrollbar.value += scrollbarValueIncrement;
                 incrementCounter++;
@@ -204,9 +207,9 @@ public class TextToSpeechHandler : MonoBehaviour
 
             // Wait for TTS to go through the current word before saying the next.
             yield return new WaitForSeconds(timeToSpeak);
-            
+
         }
-        speakingSentence = false; 
+        speakingSentence = false;
     }
 
     // Event hook for the start of a speech
@@ -221,13 +224,13 @@ public class TextToSpeechHandler : MonoBehaviour
     {
         // No longer speaking
         isSpeaking = false;
-        
+
         // Reset Variables
         index = -1;
         tick = 0;
 
         //
-        if(speakingSentence)
+        if (speakingSentence)
         {
             //
             speakingSentence = false;
@@ -238,7 +241,7 @@ public class TextToSpeechHandler : MonoBehaviour
             //     //
             //     wordTiles.Last().Highlight();
             // }
-            
+
         }
     }
 
@@ -249,7 +252,7 @@ public class TextToSpeechHandler : MonoBehaviour
         if (!highlight) return;
 
         //
-        if(speakingSentence)
+        if (speakingSentence)
         {
             // The variable tick will be 0 when the previous tile is done
             // When that is the case...
@@ -260,7 +263,7 @@ public class TextToSpeechHandler : MonoBehaviour
 
                 // The text on this tile
                 WordTile wt = wordTiles[index] as WordTile;
-                string textToRead =  wt.textToDisplay;
+                string textToRead = wt.textToDisplay;
 
                 // Calculate the number of ticks this tile will get depending upon how many words are on the tile
                 tick = textToRead.Split(' ').Length;
@@ -296,20 +299,22 @@ public class TextToSpeechHandler : MonoBehaviour
         // Stop speaking
         Speaker.Silence();
 
-        //
         isSpeaking = false;
     }
     // returns an approximation of how long the speaker needs to read a sentence
-    public float getApproxSpeechTime(List<WordTile> wordTiles){
+    public float getApproxSpeechTime(List<WordTile> wordTiles)
+    {
         float speechDuration = 0;
-        foreach(WordTile tile in wordTiles){
+        foreach (WordTile tile in wordTiles)
+        {
             speechDuration += Speaker.ApproximateSpeechLength(tile.word.baseWord);
         }
         speechDuration = speechDuration / voiceRate; // account for changing voice speed
         return speechDuration;
     }
 
-    public float getVoiceRate() {
+    public float getVoiceRate()
+    {
         return voiceRate;
     }
 }


### PR DESCRIPTION
Now both functions will only fire if the TTS's speakingSentence bool allows it and will otherwise throw a Debug.Log message.

It would probably be a good idea to include some visual indication of the lever/TTS button being busy when it fails. Maybe something like horizontal shaking or graying out the button while it's unavailable?