### PR TITLE
Fix issue where scrollbar would remain upon story submission

### DIFF
--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -832,6 +832,7 @@ MonoBehaviour:
   storyNameInputField: {fileID: 785302505}
   sentenceBank: {fileID: 396208986}
   successNoise: {fileID: 128453135}
+  scrollbar: {fileID: 1218507556}
 --- !u!114 &128453133
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2397,6 +2398,7 @@ GameObject:
   - component: {fileID: 396208987}
   - component: {fileID: 396208989}
   - component: {fileID: 396208988}
+  - component: {fileID: 396208990}
   m_Layer: 5
   m_Name: SavedSentenceBank
   m_TagString: Untagged
@@ -2420,7 +2422,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -400.50464, y: 252.00002}
+  m_AnchoredPosition: {x: -400.50464, y: 252.00093}
   m_SizeDelta: {x: 801.01, y: 500}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &396208986
@@ -2441,6 +2443,7 @@ MonoBehaviour:
   sentenceBuilderTouchBlock: {fileID: 1270179279}
   scrollBar: {fileID: 1778529701}
   sentences: []
+  sentenceIds: []
 --- !u!114 &396208987
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2495,6 +2498,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   audio: {fileID: 1458278303}
   sentenceScrollbar: {fileID: 0}
+--- !u!114 &396208990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 396208984}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
 --- !u!1 &406503547
 GameObject:
   m_ObjectHideFlags: 0
@@ -6964,7 +6981,19 @@ MonoBehaviour:
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: 
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: 
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1218507559
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This commit fixes an issue where the scrollbar would still be there after the user submitted a story and all the sentences were cleared.