### PR TITLE
Change word form holder

### DIFF
--- a/Assets/Scenes/Sentence Builder/DraggableTile.cs
+++ b/Assets/Scenes/Sentence Builder/DraggableTile.cs
@@ -71,9 +71,15 @@ public class DraggableTile : MonoBehaviour, IBeginDragHandler, IDragHandler, IEn
             //
             placeholder.transform.SetAsLastSibling();
         }
-        else
+        else if (draggedFrom == TileDropzone.Behavior.WordHolder && NewWordHolder.instance != null)
         {
+            if(NewWordHolder.instance.gameObject.activeSelf) {
+                NewWordHolder.instance.gameObject.SetActive(false);
+            }
             //
+            placeholder.transform.SetSiblingIndex(this.transform.GetSiblingIndex());
+        }
+        else {
             placeholder.transform.SetSiblingIndex(this.transform.GetSiblingIndex());
         }
 

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -144,6 +144,7 @@ MonoBehaviour:
   baseWordT: {fileID: 8020127765071357092}
   baseWordGO: {fileID: 3210380517934440383}
   TTS: {fileID: 1214538165}
+  wordHolder: {fileID: 107012080}
   wordHolderDrop: {fileID: 7598417968809258705}
   defaultHeightWidth: {x: 59.7756, y: 169.8303}
 --- !u!1 &11255648
@@ -1142,11 +1143,11 @@ RectTransform:
   - {fileID: 1944421430}
   - {fileID: 1696695520}
   - {fileID: 107012080}
+  - {fileID: 1844566991}
   - {fileID: 960626487}
   - {fileID: 138376905}
   - {fileID: 1109885698}
   - {fileID: 690792488}
-  - {fileID: 1844566991}
   - {fileID: 1494685787}
   - {fileID: 170142081}
   - {fileID: 1460180230}
@@ -1208,7 +1209,7 @@ RectTransform:
   - {fileID: 1692775391}
   - {fileID: 2010578503}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 9
+  m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2665,7 +2666,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -400.50464, y: 252.01114}
+  m_AnchoredPosition: {x: -400.50464, y: 252.00002}
   m_SizeDelta: {x: 801.01, y: 500}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &396208986
@@ -5003,7 +5004,7 @@ RectTransform:
   - {fileID: 2023912234}
   - {fileID: 182701609}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 11
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6393,7 +6394,7 @@ RectTransform:
   - {fileID: 1697865870}
   - {fileID: 1428679919}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7314,7 +7315,7 @@ RectTransform:
   m_Children:
   - {fileID: 819087555}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 10
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -7789,7 +7790,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1969722462}
   m_Direction: 2
   m_Value: 0
-  m_Size: 0.9049614
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -15214,7 +15215,7 @@ PrefabInstance:
     - target: {fileID: 7598417966969124127, guid: 35ae01cc62795f349aaec6010f24a81c,
         type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 7598417966969124127, guid: 35ae01cc62795f349aaec6010f24a81c,
         type: 3}

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -135,7 +135,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fbaba73dbda36144b8c90f4f0b29e662, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  closeForms: {fileID: 8054022035302164379}
   newFormsPopUp: {fileID: 7387002058794206984}
   popUpBackground: {fileID: 7855274498234564937}
   baseWord: {fileID: 314866219024207062}
@@ -7790,7 +7789,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1969722462}
   m_Direction: 2
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.99998176
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -14591,25 +14590,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2092331155}
   m_CullTransparentMesh: 0
---- !u!1 &26003516423329891
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4352010944948679688}
-  - component: {fileID: 3563495082443705755}
-  - component: {fileID: 8543700854641989364}
-  - component: {fileID: 8054022035302164379}
-  m_Layer: 7
-  m_Name: Close
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &314866219024207062
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14700,25 +14680,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!224 &1331889112644259919
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6178612902647445173}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 4352010944948679688}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2918929645394430135
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -14776,14 +14737,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!222 &3342575445204480956
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6178612902647445173}
-  m_CullTransparentMesh: 1
 --- !u!114 &3445160402117951723
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14814,14 +14767,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 6.4
---- !u!222 &3563495082443705755
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 26003516423329891}
-  m_CullTransparentMesh: 1
 --- !u!1 &3689419040676962152
 GameObject:
   m_ObjectHideFlags: 0
@@ -14840,26 +14785,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &4352010944948679688
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 26003516423329891}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1331889112644259919}
-  m_Father: {fileID: 7855274498234564937}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 6.783001, y: 6.7062073}
-  m_SizeDelta: {x: 13.566, y: 13.412399}
-  m_Pivot: {x: 1, y: 1}
 --- !u!4 &4453322925801050733
 Transform:
   m_ObjectHideFlags: 0
@@ -14915,95 +14840,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &4638946186675792930
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6178612902647445173}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: X
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 6
-  m_fontSizeBase: 6
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!114 &5403622116866549731
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -15057,24 +14893,6 @@ MonoBehaviour:
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
   m_PresetInfoIsWorld: 1
---- !u!1 &6178612902647445173
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1331889112644259919}
-  - component: {fileID: 3342575445204480956}
-  - component: {fileID: 4638946186675792930}
-  m_Layer: 7
-  m_Name: Text (TMP)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &6300234187559417887
 GameObject:
   m_ObjectHideFlags: 0
@@ -15325,8 +15143,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 4352010944948679688}
+  m_Children: []
   m_Father: {fileID: 8261944551840678925}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -15355,50 +15172,6 @@ RectTransform:
   m_AnchoredPosition: {x: 206.6, y: 97.7}
   m_SizeDelta: {x: 49.0229, y: 25.3115}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &8054022035302164379
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 26003516423329891}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 8543700854641989364}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &8261815134981575177
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -15438,36 +15211,6 @@ RectTransform:
   m_AnchoredPosition: {x: -11, y: 8.605408}
   m_SizeDelta: {x: 1109, y: 437}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &8543700854641989364
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 26003516423329891}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &8668645767313560659
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -209,6 +209,7 @@ GameObject:
   - component: {fileID: 31156710}
   - component: {fileID: 31156712}
   - component: {fileID: 31156711}
+  - component: {fileID: 31156713}
   m_Layer: 5
   m_Name: Dial
   m_TagString: Untagged
@@ -273,6 +274,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 31156709}
   m_CullTransparentMesh: 0
+--- !u!114 &31156713
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 31156709}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 31156711}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &36921185
 GameObject:
   m_ObjectHideFlags: 0
@@ -2596,7 +2641,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -400.50464, y: 252.00024}
+  m_AnchoredPosition: {x: -400.50464, y: 251.99998}
   m_SizeDelta: {x: 801.01, y: 500}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &396208986
@@ -7720,7 +7765,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1969722462}
   m_Direction: 2
   m_Value: 0
-  m_Size: 0.9840093
+  m_Size: 0.9998962
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -14642,6 +14687,11 @@ PrefabInstance:
       propertyPath: wordForms
       value: 
       objectReference: {fileID: 1377594292}
+    - target: {fileID: 7598417966969124098, guid: 35ae01cc62795f349aaec6010f24a81c,
+        type: 3}
+      propertyPath: formDialButton
+      value: 
+      objectReference: {fileID: 31156713}
     - target: {fileID: 7598417966969124098, guid: 35ae01cc62795f349aaec6010f24a81c,
         type: 3}
       propertyPath: SentenceBuilderCanvas

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -2665,7 +2665,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -400.50464, y: 252.00002}
+  m_AnchoredPosition: {x: -400.50464, y: 251.99998}
   m_SizeDelta: {x: 801.01, y: 500}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &396208986
@@ -7789,7 +7789,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1969722462}
   m_Direction: 2
   m_Value: 0
-  m_Size: 0.99998176
+  m_Size: 0.9999954
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -14932,13 +14932,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 0
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}

--- a/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
+++ b/Assets/Scenes/Sentence Builder/SentenceBuilder.unity
@@ -123,6 +123,29 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!114 &5
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7387002058794206984}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fbaba73dbda36144b8c90f4f0b29e662, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  closeForms: {fileID: 8054022035302164379}
+  newFormsPopUp: {fileID: 7387002058794206984}
+  popUpBackground: {fileID: 7855274498234564937}
+  baseWord: {fileID: 314866219024207062}
+  newFormButton: {fileID: 6657660011938354613, guid: 63c7e22329e17a24f900e9465a368b11,
+    type: 3}
+  baseWordT: {fileID: 8020127765071357092}
+  baseWordGO: {fileID: 3210380517934440383}
+  TTS: {fileID: 1214538165}
+  wordHolderDrop: {fileID: 7598417968809258705}
+  defaultHeightWidth: {x: 59.7756, y: 169.8303}
 --- !u!1 &11255648
 GameObject:
   m_ObjectHideFlags: 0
@@ -1128,6 +1151,7 @@ RectTransform:
   - {fileID: 170142081}
   - {fileID: 1460180230}
   - {fileID: 244709234}
+  - {fileID: 4453322925801050733}
   - {fileID: 1999367032}
   - {fileID: 145569876}
   - {fileID: 1270179280}
@@ -1332,7 +1356,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 18
+  m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -2641,7 +2665,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -400.50464, y: 251.99998}
+  m_AnchoredPosition: {x: -400.50464, y: 252.01114}
   m_SizeDelta: {x: 801.01, y: 500}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &396208986
@@ -7765,7 +7789,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 1969722462}
   m_Direction: 2
   m_Value: 0
-  m_Size: 0.9998962
+  m_Size: 0.9049614
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -8228,7 +8252,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 138288539}
-  m_RootOrder: 19
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -8660,115 +8684,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1372341102}
   m_CullTransparentMesh: 0
---- !u!1001 &1377594291
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1377594294, guid: e35375678d445d548a58e0fb3572c1c0, type: 3}
-      propertyPath: wordHolderDrop
-      value: 
-      objectReference: {fileID: 7598417968809258705}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 45.43
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.3945923
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4453322926571518430, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4583794292457192493, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_Camera
-      value: 
-      objectReference: {fileID: 1630840809}
-    - target: {fileID: 7387002060171799739, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_Name
-      value: NewWordHolderPopup
-      objectReference: {fileID: 0}
-    - target: {fileID: 7387002060171799739, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7855274499609504506, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 206.59778
-      objectReference: {fileID: 0}
-    - target: {fileID: 7855274499609504506, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -100.398026
-      objectReference: {fileID: 0}
-    - target: {fileID: 8020127765842824983, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 206.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 8020127765842824983, guid: e35375678d445d548a58e0fb3572c1c0,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 97.7
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e35375678d445d548a58e0fb3572c1c0, type: 3}
---- !u!1 &1377594292 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7387002060171799739, guid: e35375678d445d548a58e0fb3572c1c0,
-    type: 3}
-  m_PrefabInstance: {fileID: 1377594291}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1411588349
 GameObject:
   m_ObjectHideFlags: 0
@@ -13856,7 +13771,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1999367031
 GameObject:
@@ -13893,7 +13808,7 @@ RectTransform:
   - {fileID: 236464769}
   - {fileID: 1577819580}
   m_Father: {fileID: 138288539}
-  m_RootOrder: 17
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -14675,6 +14590,585 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2092331155}
   m_CullTransparentMesh: 0
+--- !u!1 &26003516423329891
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4352010944948679688}
+  - component: {fileID: 3563495082443705755}
+  - component: {fileID: 8543700854641989364}
+  - component: {fileID: 8054022035302164379}
+  m_Layer: 7
+  m_Name: Close
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &314866219024207062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6300234187559417887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 902badcc22110a04caf3e8e91e6d177f, type: 2}
+  m_sharedMaterial: {fileID: -4665559937232615107, guid: 902badcc22110a04caf3e8e91e6d177f,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 6
+  m_fontSizeBase: 6
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 2
+  m_fontSizeMax: 10
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 3
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!224 &1331889112644259919
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6178612902647445173}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4352010944948679688}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2918929645394430135
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3210380517934440383}
+  m_CullTransparentMesh: 1
+--- !u!114 &3042527968730659163
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8668645767313560659}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3210380517934440383
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8020127765071357092}
+  - component: {fileID: 2918929645394430135}
+  - component: {fileID: 5403622116866549731}
+  - component: {fileID: 7068419855778887007}
+  m_Layer: 7
+  m_Name: wordForm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &3342575445204480956
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6178612902647445173}
+  m_CullTransparentMesh: 1
+--- !u!114 &3445160402117951723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3689419040676962152}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: d7839a2f7a947524a89c0001f80eff8f, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 6.4
+--- !u!222 &3563495082443705755
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26003516423329891}
+  m_CullTransparentMesh: 1
+--- !u!1 &3689419040676962152
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7855274498234564937}
+  - component: {fileID: 8821390987528326676}
+  - component: {fileID: 3445160402117951723}
+  m_Layer: 7
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4352010944948679688
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26003516423329891}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1331889112644259919}
+  m_Father: {fileID: 7855274498234564937}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 6.783001, y: 6.7062073}
+  m_SizeDelta: {x: 13.566, y: 13.412399}
+  m_Pivot: {x: 1, y: 1}
+--- !u!4 &4453322925801050733
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7387002058794206984}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 40.43, y: -24.605408, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8261944551840678925}
+  m_Father: {fileID: 138288539}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!224 &4551315473394673237
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8668645767313560659}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8261944551840678925}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1024, y: 768}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &4583794291146741662
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8766358313916506400}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 1630840809}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &4638946186675792930
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6178612902647445173}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: X
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 6
+  m_fontSizeBase: 6
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &5403622116866549731
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3210380517934440383}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 5111258645361d04a839608aef708347, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5571382957219474303
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8766358313916506400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!1 &6178612902647445173
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1331889112644259919}
+  - component: {fileID: 3342575445204480956}
+  - component: {fileID: 4638946186675792930}
+  m_Layer: 7
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &6300234187559417887
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9220417911543411746}
+  - component: {fileID: 7498441756303508769}
+  - component: {fileID: 314866219024207062}
+  m_Layer: 7
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &6782857689662887276
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8668645767313560659}
+  m_CullTransparentMesh: 0
+--- !u!114 &7068419855778887007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3210380517934440383}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.8396226, g: 0.74039704, b: 0.09029898, a: 1}
+    m_SelectedColor: {r: 0.8392157, g: 0.7411765, b: 0.09019608, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5403622116866549731}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &7387002058794206984
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4453322925801050733}
+  - component: {fileID: 5}
+  m_Layer: 7
+  m_Name: NewWordHolderPopup
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!222 &7498441756303508769
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6300234187559417887}
+  m_CullTransparentMesh: 1
 --- !u!1001 &7598417968809258704
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -14686,7 +15180,7 @@ PrefabInstance:
         type: 3}
       propertyPath: wordForms
       value: 
-      objectReference: {fileID: 1377594292}
+      objectReference: {fileID: 7387002058794206984}
     - target: {fileID: 7598417966969124098, guid: 35ae01cc62795f349aaec6010f24a81c,
         type: 3}
       propertyPath: formDialButton
@@ -14820,3 +15314,220 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 7598417968809258704}
   m_PrefabAsset: {fileID: 0}
+--- !u!224 &7855274498234564937
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3689419040676962152}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4352010944948679688}
+  m_Father: {fileID: 8261944551840678925}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 206.59778, y: -100.398026}
+  m_SizeDelta: {x: 59.7756, y: 169.8303}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!224 &8020127765071357092
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3210380517934440383}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 9220417911543411746}
+  m_Father: {fileID: 8261944551840678925}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 206.6, y: 97.7}
+  m_SizeDelta: {x: 49.0229, y: 25.3115}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8054022035302164379
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26003516423329891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8543700854641989364}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &8261815134981575177
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8766358313916506400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!224 &8261944551840678925
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8766358313916506400}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalScale: {x: 1.8306636, y: 1.8306636, z: 1.8306636}
+  m_Children:
+  - {fileID: 4551315473394673237}
+  - {fileID: 7855274498234564937}
+  - {fileID: 8020127765071357092}
+  m_Father: {fileID: 4453322925801050733}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -11, y: 8.605408}
+  m_SizeDelta: {x: 1109, y: 437}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &8543700854641989364
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26003516423329891}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8668645767313560659
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4551315473394673237}
+  - component: {fileID: 6782857689662887276}
+  - component: {fileID: 3042527968730659163}
+  m_Layer: 6
+  m_Name: TintScreen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &8766358313916506400
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8261944551840678925}
+  - component: {fileID: 4583794291146741662}
+  - component: {fileID: 5571382957219474303}
+  - component: {fileID: 8261815134981575177}
+  m_Layer: 7
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!222 &8821390987528326676
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3689419040676962152}
+  m_CullTransparentMesh: 1
+--- !u!224 &9220417911543411746
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6300234187559417887}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 8020127765071357092}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -6.3755, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Scenes/Sentence Builder/TileDropzone.cs
+++ b/Assets/Scenes/Sentence Builder/TileDropzone.cs
@@ -189,7 +189,7 @@ public class TileDropzone : MonoBehaviour, IDropHandler, IPointerEnterHandler, I
                         Destroy(this.transform.GetChild(0).gameObject);
                     }
                     
-                    GetComponent<WordHolder>().OpenWordHolder(eventData.pointerDrag.GetComponent<WordTile>().word);
+                    //GetComponent<WordHolder>().OpenWordHolder(eventData.pointerDrag.GetComponent<WordTile>().word);
 
                     //
                     Destroy(d.placeholder);

--- a/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
@@ -51,7 +51,7 @@ public class NewWordHolder : MonoBehaviour
     // Start is called before the first frame update
     void Awake()
     {
-        baseWordGO.GetComponentInChildren<Button>().onClick.AddListener(() => TaskOnClick2());
+        baseWordGO.GetComponentInChildren<Button>().onClick.AddListener(() => baseWordClick(baseWordGO.GetComponent<Image>()));
         instance = this;
         wordHolderSiblingIndex = wordHolder.GetSiblingIndex();
         wordHolderDropZoneSiblingIndex = wordHolderDrop.transform.GetSiblingIndex();
@@ -85,7 +85,7 @@ public class NewWordHolder : MonoBehaviour
                 string wordFormText = word2.forms[i];
                 Debug.Log(i);
                 button.transform.position = new Vector3(baseWordT.position.x, baseWordT.position.y - offset, baseWordT.position.z);
-                button.GetComponent<Button>().onClick.AddListener(() => TaskOnClick(word2, wordFormText));
+                button.GetComponent<Button>().onClick.AddListener(() => formClick(word2, wordFormText, button.GetComponent<Image>()));
                 offset += 50;
                 buttons.Add(button);
             // float offset = 1;
@@ -103,30 +103,36 @@ public class NewWordHolder : MonoBehaviour
             
         }
 
-
-
-        void TaskOnClick(Word word2, string wordFormText) {
+        void formClick(Word word2, string wordFormText, Image buttonImage) {
              // update word counts for the learner
             LearnerDataHandler.UpdateWordCount(wordFormText);
             // store it locally
             LearnerDataHandler.StoreLearnerData();
             // update the server's copy
             StartCoroutine(ServerRequestHandler.PostLearnerDataToServer());
+            StartCoroutine(HighlightButton(Speaker.Instance.ApproximateSpeechLength(wordFormText), buttonImage));
             TTS.startSpeakingWordTile(wordFormText);
             wordHolderDrop.GetComponentInChildren<Text>().text = wordFormText;
             wordHolderDrop.GetComponentInChildren<WordTile>().textToDisplay = wordFormText;
         }
 
-        void TaskOnClick2() {
+        void baseWordClick(Image buttonImage) {
              // update word counts for the learner
             LearnerDataHandler.UpdateWordCount(baseWord.text);
             // store it locally
             LearnerDataHandler.StoreLearnerData();
             // update the server's copy
             StartCoroutine(ServerRequestHandler.PostLearnerDataToServer());
+            StartCoroutine(HighlightButton(Speaker.Instance.ApproximateSpeechLength(baseWord.text), buttonImage));
             TTS.startSpeakingWordTile(baseWord.text);
              wordHolderDrop.GetComponentInChildren<Text>().text = baseWord.text;
              wordHolderDrop.GetComponentInChildren<WordTile>().textToDisplay = baseWord.text;
+        }
+
+        private IEnumerator HighlightButton(float seconds, Image buttonImage) {
+            buttonImage.color = Color.yellow;
+            yield return new WaitForSeconds(seconds);
+            buttonImage.color = Color.white;
         }
     }
 

--- a/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
@@ -10,8 +10,6 @@ public class NewWordHolder : MonoBehaviour
     public static NewWordHolder instance;
 
     [SerializeField]
-    private Button closeForms;
-    [SerializeField]
     private GameObject newFormsPopUp;
 
     [SerializeField]
@@ -53,7 +51,6 @@ public class NewWordHolder : MonoBehaviour
     // Start is called before the first frame update
     void Awake()
     {
-        closeForms.onClick.AddListener(()=> newFormsPopUp.SetActive(false));
         baseWordGO.GetComponentInChildren<Button>().onClick.AddListener(() => TaskOnClick2());
         instance = this;
         wordHolderSiblingIndex = wordHolder.GetSiblingIndex();

--- a/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
@@ -63,7 +63,6 @@ public class NewWordHolder : MonoBehaviour
         baseWord.text = word2.baseWord;
         wordHolder.SetSiblingIndex(wordFormPopupSiblingIndex + 1);
         wordHolderDrop.transform.SetSiblingIndex(wordFormPopupSiblingIndex + 2);
-        wordHolderDrop.GetComponentInChildren<CanvasGroup>().blocksRaycasts = false;
     }
 
     void OnDisable() {
@@ -74,7 +73,6 @@ public class NewWordHolder : MonoBehaviour
         popUpBackground.sizeDelta = defaultHeightWidth;
         wordHolder.SetSiblingIndex(wordHolderSiblingIndex);
         wordHolderDrop.transform.SetSiblingIndex(wordHolderDropZoneSiblingIndex);
-        wordHolderDrop.GetComponentInChildren<CanvasGroup>().blocksRaycasts = true;
     }
 
     public void setUpForms() {

--- a/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using Crosstales.RTVoice;
 
 public class NewWordHolder : MonoBehaviour
 {
@@ -27,6 +28,9 @@ public class NewWordHolder : MonoBehaviour
 
     [SerializeField]
     private GameObject baseWordGO;
+
+    [SerializeField]
+    private TextToSpeechHandler TTS;
 
     [SerializeField] 
     private GameObject wordHolderDrop; 
@@ -89,14 +93,26 @@ public class NewWordHolder : MonoBehaviour
 
 
 
-        void TaskOnClick(Word word2, string i) {
-            //Debug.Log("You have been clicked");
-            Debug.Log(i);
-            wordHolderDrop.GetComponentInChildren<Text>().text = i;
-            wordHolderDrop.GetComponentInChildren<WordTile>().textToDisplay = i;
+        void TaskOnClick(Word word2, string wordFormText) {
+             // update word counts for the learner
+            LearnerDataHandler.UpdateWordCount(wordFormText);
+            // store it locally
+            LearnerDataHandler.StoreLearnerData();
+            // update the server's copy
+            StartCoroutine(ServerRequestHandler.PostLearnerDataToServer());
+            TTS.startSpeakingWordTile(wordFormText);
+            wordHolderDrop.GetComponentInChildren<Text>().text = wordFormText;
+            wordHolderDrop.GetComponentInChildren<WordTile>().textToDisplay = wordFormText;
         }
 
         void TaskOnClick2() {
+             // update word counts for the learner
+            LearnerDataHandler.UpdateWordCount(baseWord.text);
+            // store it locally
+            LearnerDataHandler.StoreLearnerData();
+            // update the server's copy
+            StartCoroutine(ServerRequestHandler.PostLearnerDataToServer());
+            TTS.startSpeakingWordTile(baseWord.text);
              wordHolderDrop.GetComponentInChildren<Text>().text = baseWord.text;
              wordHolderDrop.GetComponentInChildren<WordTile>().textToDisplay = baseWord.text;
         }

--- a/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
@@ -32,8 +32,12 @@ public class NewWordHolder : MonoBehaviour
     [SerializeField]
     private TextToSpeechHandler TTS;
 
+    [SerializeField]
+    private Transform wordHolder;
+
     [SerializeField] 
     private GameObject wordHolderDrop; 
+
     [SerializeField]
     private Vector2 defaultHeightWidth;
 
@@ -41,17 +45,29 @@ public class NewWordHolder : MonoBehaviour
 
     public static Word word2;
 
+    private int wordHolderSiblingIndex;
+    private int wordHolderDropZoneSiblingIndex;
+
+    private int wordFormPopupSiblingIndex;
+
     // Start is called before the first frame update
-    void Start()
+    void Awake()
     {
         closeForms.onClick.AddListener(()=> newFormsPopUp.SetActive(false));
-         baseWordGO.GetComponentInChildren<Button>().onClick.AddListener(() => TaskOnClick2());
+        baseWordGO.GetComponentInChildren<Button>().onClick.AddListener(() => TaskOnClick2());
         instance = this;
+        wordHolderSiblingIndex = wordHolder.GetSiblingIndex();
+         Debug.Log("Word Holder sibling index: " + wordHolderSiblingIndex);
+        wordHolderDropZoneSiblingIndex = wordHolderDrop.transform.GetSiblingIndex();
+        wordFormPopupSiblingIndex = this.transform.GetSiblingIndex();
     }
 
     void OnEnable()
     {
         baseWord.text = word2.baseWord;
+        wordHolder.SetSiblingIndex(wordFormPopupSiblingIndex + 1);
+        wordHolderDrop.transform.SetSiblingIndex(wordFormPopupSiblingIndex + 2);
+        wordHolderDrop.GetComponentInChildren<CanvasGroup>().blocksRaycasts = false;
     }
 
     void OnDisable() {
@@ -60,7 +76,9 @@ public class NewWordHolder : MonoBehaviour
         }
         
         popUpBackground.sizeDelta = defaultHeightWidth;
-
+        wordHolder.SetSiblingIndex(wordHolderSiblingIndex);
+        wordHolderDrop.transform.SetSiblingIndex(wordHolderDropZoneSiblingIndex);
+        wordHolderDrop.GetComponentInChildren<CanvasGroup>().blocksRaycasts = true;
     }
 
     public void setUpForms() {

--- a/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolder.cs
@@ -54,7 +54,6 @@ public class NewWordHolder : MonoBehaviour
         baseWordGO.GetComponentInChildren<Button>().onClick.AddListener(() => TaskOnClick2());
         instance = this;
         wordHolderSiblingIndex = wordHolder.GetSiblingIndex();
-         Debug.Log("Word Holder sibling index: " + wordHolderSiblingIndex);
         wordHolderDropZoneSiblingIndex = wordHolderDrop.transform.GetSiblingIndex();
         wordFormPopupSiblingIndex = this.transform.GetSiblingIndex();
     }

--- a/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolderPopup.prefab
+++ b/Assets/Scenes/Sentence Builder/Word Holder/NewWordHolderPopup.prefab
@@ -375,7 +375,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fbaba73dbda36144b8c90f4f0b29e662, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  closeForms: {fileID: 8054022033925131304}
   newFormsPopUp: {fileID: 7387002060171799739}
   popUpBackground: {fileID: 7855274499609504506}
   baseWord: {fileID: 314866217714788197}
@@ -383,6 +382,8 @@ MonoBehaviour:
     type: 3}
   baseWordT: {fileID: 8020127765842824983}
   baseWordGO: {fileID: 3210380516625576972}
+  TTS: {fileID: 0}
+  wordHolder: {fileID: 0}
   wordHolderDrop: {fileID: 0}
   defaultHeightWidth: {x: 59.7756, y: 169.8303}
 --- !u!1 &8766358314689055379

--- a/Assets/Scenes/Sentence Builder/Word Holder/WordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/WordHolder.cs
@@ -11,6 +11,11 @@ public class WordHolder : MonoBehaviour
 
     [SerializeField]
     private GameObject wordForms;
+    public static Transform wordHolderDropZoneTransform;
+
+    public void Start() {
+        wordHolderDropZoneTransform = this.transform;
+    }
 
     public void OpenWordHolder(Word word)
     {

--- a/Assets/Scenes/Sentence Builder/Word Holder/WordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/WordHolder.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class WordHolder : MonoBehaviour
 {
@@ -11,10 +12,16 @@ public class WordHolder : MonoBehaviour
 
     [SerializeField]
     private GameObject wordForms;
+
+
+    [SerializeField]
+    private Button formDialButton;
     public static Transform wordHolderDropZoneTransform;
 
     public void Start() {
         wordHolderDropZoneTransform = this.transform;
+        formDialButton.onClick.AddListener(()=> OpenWordHolder(wordHolderDropZoneTransform.GetChild(0).GetComponent<WordTile>().word));
+
     }
 
     public void OpenWordHolder(Word word)

--- a/Assets/Scenes/Sentence Builder/Word Holder/WordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/WordHolder.cs
@@ -21,8 +21,11 @@ public class WordHolder : MonoBehaviour
     public void Start() {
         wordHolderDropZoneTransform = this.transform;
         formDialButton.onClick.AddListener(()=> {
-            if(WordHolder.wordHolderDropZoneTransform.childCount > 0) {
+            if(WordHolder.wordHolderDropZoneTransform.childCount > 0 && !wordForms.activeSelf) {
                  OpenWordHolder(wordHolderDropZoneTransform.GetChild(0).GetComponent<WordTile>().word);
+            }
+            else {
+                wordForms.SetActive(false);
             }
         });
     }

--- a/Assets/Scenes/Sentence Builder/Word Holder/WordHolder.cs
+++ b/Assets/Scenes/Sentence Builder/Word Holder/WordHolder.cs
@@ -20,8 +20,11 @@ public class WordHolder : MonoBehaviour
 
     public void Start() {
         wordHolderDropZoneTransform = this.transform;
-        formDialButton.onClick.AddListener(()=> OpenWordHolder(wordHolderDropZoneTransform.GetChild(0).GetComponent<WordTile>().word));
-
+        formDialButton.onClick.AddListener(()=> {
+            if(WordHolder.wordHolderDropZoneTransform.childCount > 0) {
+                 OpenWordHolder(wordHolderDropZoneTransform.GetChild(0).GetComponent<WordTile>().word);
+            }
+        });
     }
 
     public void OpenWordHolder(Word word)

--- a/Assets/Scenes/Sentence Builder/Word Holder/wordForm.prefab
+++ b/Assets/Scenes/Sentence Builder/Word Holder/wordForm.prefab
@@ -225,18 +225,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
-    m_Mode: 3
+    m_Mode: 0
     m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
     m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
+  m_Transition: 0
   m_Colors:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.8396226, g: 0.74039704, b: 0.09029898, a: 1}
-    m_SelectedColor: {r: 0.8392157, g: 0.7411765, b: 0.09019608, a: 1}
+    m_PressedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_SelectedColor: {r: 1, g: 1, b: 1, a: 0}
     m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1

--- a/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
+++ b/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
@@ -40,6 +40,18 @@ public class WordTile : MonoBehaviour, IPointerClickHandler
         // Speak the text on the tile using the correct voice
         TTS = GetComponentInParent<TextToSpeechHandler>();
         TTS.startSpeakingWordTile(textToRead);
+
+        GameObject o = Instantiate(this.gameObject);
+        o.GetComponent<WordTile>().word = this.gameObject.GetComponent<WordTile>().word;
+        o.GetComponent<Image>().color = this.gameObject.GetComponent<WordTile>().originalColor;
+
+        if(WordHolder.wordHolderDropZoneTransform.childCount > 0) {
+            GameObject.Destroy(WordHolder.wordHolderDropZoneTransform.GetChild(0).gameObject);
+            o.transform.SetParent(WordHolder.wordHolderDropZoneTransform, false);
+        }
+        else {
+            o.transform.SetParent(WordHolder.wordHolderDropZoneTransform, false);
+        }
     }
 
     // public void Highlight()

--- a/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
+++ b/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
@@ -41,18 +41,22 @@ public class WordTile : MonoBehaviour, IPointerClickHandler
         TTS = GetComponentInParent<TextToSpeechHandler>();
         TTS.startSpeakingWordTile(textToRead);
 
-        GameObject o = Instantiate(this.gameObject);
-        o.GetComponent<WordTile>().word = this.gameObject.GetComponent<WordTile>().word;
-        o.GetComponent<Image>().color = this.gameObject.GetComponent<WordTile>().originalColor;
 
-        if(WordHolder.wordHolderDropZoneTransform.childCount > 0) {
-            GameObject.Destroy(WordHolder.wordHolderDropZoneTransform.GetChild(0).gameObject);
-            o.transform.SetParent(WordHolder.wordHolderDropZoneTransform, false);
-            o.GetComponent<DraggableTile>().draggedFrom = TileDropzone.Behavior.WordHolder;
-        }
-        else {
-            o.transform.SetParent(WordHolder.wordHolderDropZoneTransform, false);
-            o.GetComponent<DraggableTile>().draggedFrom = TileDropzone.Behavior.WordHolder;
+        if(this.gameObject.GetComponent<DraggableTile>().draggedFrom != TileDropzone.Behavior.WordHolder) {
+
+            GameObject o = Instantiate(this.gameObject);
+            o.GetComponent<WordTile>().word = this.gameObject.GetComponent<WordTile>().word;
+            o.GetComponent<Image>().color = this.gameObject.GetComponent<WordTile>().originalColor;
+
+            if(WordHolder.wordHolderDropZoneTransform.childCount > 0) {
+                GameObject.Destroy(WordHolder.wordHolderDropZoneTransform.GetChild(0).gameObject);
+                o.transform.SetParent(WordHolder.wordHolderDropZoneTransform, false);
+                o.GetComponent<DraggableTile>().draggedFrom = TileDropzone.Behavior.WordHolder;
+            }
+            else {
+                o.transform.SetParent(WordHolder.wordHolderDropZoneTransform, false);
+                o.GetComponent<DraggableTile>().draggedFrom = TileDropzone.Behavior.WordHolder;
+            }
         }
     }
 

--- a/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
+++ b/Assets/Scenes/Sentence Builder/Word Tile/WordTile.cs
@@ -48,9 +48,11 @@ public class WordTile : MonoBehaviour, IPointerClickHandler
         if(WordHolder.wordHolderDropZoneTransform.childCount > 0) {
             GameObject.Destroy(WordHolder.wordHolderDropZoneTransform.GetChild(0).gameObject);
             o.transform.SetParent(WordHolder.wordHolderDropZoneTransform, false);
+            o.GetComponent<DraggableTile>().draggedFrom = TileDropzone.Behavior.WordHolder;
         }
         else {
             o.transform.SetParent(WordHolder.wordHolderDropZoneTransform, false);
+            o.GetComponent<DraggableTile>().draggedFrom = TileDropzone.Behavior.WordHolder;
         }
     }
 


### PR DESCRIPTION
This pull request implements several changes to how the word form holder functions/looks. The word form holder is no longer tinted when the word forms pop up is open. When users tap on a tile, that tile now automatically shows up in the word form holder. Additionally, in order to open the word forms, the user must now click on the green dial. TTS now speaks the word forms and they highlight in the same way that regular word tiles do. In order to close the forms popup, the user can click on the green dial or drag the tile in word form holder out. 